### PR TITLE
Add comprehensive reverse geocoding with OSM and Google providers

### DIFF
--- a/biosample_enricher/cli_biosample_elevation.py
+++ b/biosample_enricher/cli_biosample_elevation.py
@@ -172,7 +172,7 @@ def enrich(
 
                         try:
                             # Get elevation observations
-                            observations = await service.get_elevation(
+                            observations = service.get_elevation(
                                 elevation_request,
                                 timeout_s=timeout,
                                 read_from_cache=use_cache,

--- a/biosample_enricher/cli_elevation.py
+++ b/biosample_enricher/cli_elevation.py
@@ -85,7 +85,7 @@ def lookup_elevation(
                 )
 
             # Get observations
-            observations = await service.get_elevation(
+            observations = service.get_elevation(
                 request,
                 timeout_s=timeout,
                 read_from_cache=use_read_cache,
@@ -228,7 +228,7 @@ def batch_elevation(
                             preferred_providers=provider_list,
                         )
 
-                        observations = await service.get_elevation(
+                        observations = service.get_elevation(
                             request,
                             timeout_s=timeout,
                             read_from_cache=use_read_cache,

--- a/biosample_enricher/elevation/providers/google.py
+++ b/biosample_enricher/elevation/providers/google.py
@@ -36,7 +36,7 @@ class GoogleElevationProvider(BaseElevationProvider):
 
         logger.info("Google Elevation provider initialized")
 
-    async def fetch(
+    def fetch(
         self,
         lat: float,
         lon: float,

--- a/biosample_enricher/elevation/providers/open_topo_data.py
+++ b/biosample_enricher/elevation/providers/open_topo_data.py
@@ -31,7 +31,7 @@ class OpenTopoDataProvider(BaseElevationProvider):
         self.dataset = dataset
         logger.info(f"Open Topo Data provider initialized: {dataset} dataset")
 
-    async def fetch(
+    def fetch(
         self,
         lat: float,
         lon: float,
@@ -184,7 +184,7 @@ class SmartOpenTopoDataProvider(BaseElevationProvider):
         # Default to SRTM 30m for best global coverage
         return "srtm30m"
 
-    async def fetch(
+    def fetch(
         self,
         lat: float,
         lon: float,
@@ -202,7 +202,7 @@ class SmartOpenTopoDataProvider(BaseElevationProvider):
         provider = OpenTopoDataProvider(endpoint=self.endpoint_base, dataset=dataset)
 
         # Delegate to specific provider
-        return await provider.fetch(
+        return provider.fetch(
             lat,
             lon,
             read_from_cache=read_from_cache,

--- a/biosample_enricher/elevation/providers/osm.py
+++ b/biosample_enricher/elevation/providers/osm.py
@@ -25,7 +25,7 @@ class OSMElevationProvider(BaseElevationProvider):
         super().__init__(name="osm_elevation", endpoint=endpoint, api_version="v1")
         logger.info(f"OSM Elevation provider initialized: {endpoint}")
 
-    async def fetch(
+    def fetch(
         self,
         lat: float,
         lon: float,

--- a/biosample_enricher/elevation/providers/usgs.py
+++ b/biosample_enricher/elevation/providers/usgs.py
@@ -22,7 +22,7 @@ class USGSElevationProvider(BaseElevationProvider):
         )
         logger.info("USGS Elevation provider initialized")
 
-    async def fetch(
+    def fetch(
         self,
         lat: float,
         lon: float,

--- a/biosample_enricher/elevation/service.py
+++ b/biosample_enricher/elevation/service.py
@@ -208,7 +208,7 @@ class ElevationService:
         logger.debug(f"Selected providers: {[p.name for p in selected]}")
         return selected
 
-    async def get_elevation(
+    def get_elevation(
         self,
         request: ElevationRequest,
         *,
@@ -248,7 +248,7 @@ class ElevationService:
                 logger.debug(f"Fetching from {provider.name}")
 
                 # Fetch from provider
-                result = await provider.fetch(
+                result = provider.fetch(
                     lat,
                     lon,
                     read_from_cache=read_from_cache,

--- a/biosample_enricher/elevation_demos.py
+++ b/biosample_enricher/elevation_demos.py
@@ -124,7 +124,7 @@ def process_biosamples(
                         )
 
                         try:
-                            observations = await service.get_elevation(
+                            observations = service.get_elevation(
                                 request,
                                 timeout_s=timeout,
                                 read_from_cache=use_cache,
@@ -275,7 +275,7 @@ def compare_providers(lat: float, lon: float, providers: str, output: str) -> No
             latitude=lat, longitude=lon, preferred_providers=provider_list
         )
 
-        observations = await service.get_elevation(request)
+        observations = service.get_elevation(request)
 
         # Create comparison table
         table = Table(title=f"Provider Comparison: {lat:.6f}, {lon:.6f}")

--- a/biosample_enricher/geocoding_comprehensive_demo.py
+++ b/biosample_enricher/geocoding_comprehensive_demo.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python
+"""
+Comprehensive demonstration of all geocoding services.
+
+Shows Google and OSM providers for both elevation and reverse geocoding.
+"""
+
+import json
+import os
+import sys
+import time
+from typing import Any, TypedDict
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from biosample_enricher.elevation.providers.google import GoogleElevationProvider
+from biosample_enricher.elevation.providers.osm import OSMElevationProvider
+from biosample_enricher.logging_config import get_logger
+from biosample_enricher.reverse_geocoding import (
+    GoogleReverseGeocodingProvider,
+    OSMReverseGeocodingProvider,
+)
+
+logger = get_logger(__name__)
+
+console = Console()
+
+
+class TestLocation(TypedDict):
+    """Type definition for test locations."""
+
+    name: str
+    lat: float
+    lon: float
+
+
+# Test locations
+TEST_LOCATIONS: list[TestLocation] = [
+    {"name": "Googleplex, Mountain View", "lat": 37.4224, "lon": -122.0856},
+    {"name": "Mount Everest Base Camp", "lat": 28.0026, "lon": 86.8528},
+    {"name": "Death Valley", "lat": 36.5323, "lon": -116.9325},
+    {"name": "Tokyo Tower", "lat": 35.6586, "lon": 139.7454},
+    {"name": "Pacific Ocean", "lat": 30.0, "lon": -140.0},
+]
+
+
+def test_google_apis(lat: float, lon: float, name: str) -> dict[str, Any]:
+    """Test Google APIs for a location."""
+    results = {"name": name, "lat": lat, "lon": lon}
+
+    # Test Google Elevation
+    try:
+        console.print("  [cyan]Google Elevation[/cyan]...", end="")
+        elevation_provider = GoogleElevationProvider()
+        elev_result = elevation_provider.fetch(lat, lon, read_from_cache=False)
+
+        if elev_result.ok:
+            results["google_elevation"] = {
+                "elevation_m": elev_result.elevation,
+                "resolution_m": elev_result.resolution_m,
+                "status": "success",
+            }
+            console.print(f" ✓ {elev_result.elevation:.2f}m", style="green")
+        else:
+            results["google_elevation"] = {
+                "status": "failed",
+                "error": elev_result.error,
+            }
+            console.print(f" ✗ {elev_result.error}", style="red")
+    except Exception as e:
+        results["google_elevation"] = {"status": "error", "error": str(e)}
+        console.print(f" ✗ Error: {e}", style="red")
+
+    # Test Google Reverse Geocoding
+    try:
+        console.print("  [cyan]Google Geocoding[/cyan]...", end="")
+        geocoding_provider = GoogleReverseGeocodingProvider()
+        geo_result = geocoding_provider.fetch(lat, lon, read_from_cache=False, limit=3)
+
+        if geo_result.ok and geo_result.result:
+            best = geo_result.result.get_best_match()
+            if best:
+                results["google_geocoding"] = {
+                    "address": best.formatted_address,
+                    "country": best.country,
+                    "state": best.state,
+                    "city": best.city,
+                    "status": "success",
+                }
+                console.print(f" ✓ {best.country or 'Unknown'}", style="green")
+            else:
+                results["google_geocoding"] = {"status": "no_results"}
+                console.print(" ⚠ No results", style="yellow")
+        else:
+            results["google_geocoding"] = {
+                "status": "failed",
+                "error": geo_result.error,
+            }
+            console.print(f" ✗ {geo_result.error}", style="red")
+    except Exception as e:
+        results["google_geocoding"] = {"status": "error", "error": str(e)}
+        console.print(f" ✗ Error: {e}", style="red")
+
+    return results
+
+
+def test_osm_apis(lat: float, lon: float, name: str) -> dict[str, Any]:
+    """Test OSM APIs for a location."""
+    results = {"name": name, "lat": lat, "lon": lon}
+
+    # Test OSM Elevation
+    try:
+        console.print("  [cyan]OSM Elevation[/cyan]...", end="")
+        elevation_provider = OSMElevationProvider()
+        elev_result = elevation_provider.fetch(lat, lon, read_from_cache=False)
+
+        if elev_result.ok:
+            results["osm_elevation"] = {
+                "elevation_m": elev_result.elevation,
+                "resolution_m": elev_result.resolution_m,
+                "status": "success",
+            }
+            console.print(f" ✓ {elev_result.elevation:.2f}m", style="green")
+        else:
+            results["osm_elevation"] = {"status": "failed", "error": elev_result.error}
+            console.print(f" ✗ {elev_result.error}", style="red")
+    except Exception as e:
+        results["osm_elevation"] = {"status": "error", "error": str(e)}
+        console.print(f" ✗ Error: {e}", style="red")
+
+    # Test OSM Reverse Geocoding
+    try:
+        console.print("  [cyan]OSM Geocoding[/cyan]...", end="")
+        geocoding_provider = OSMReverseGeocodingProvider()
+        geo_result = geocoding_provider.fetch(lat, lon, read_from_cache=False, limit=3)
+
+        if geo_result.ok and geo_result.result:
+            best = geo_result.result.get_best_match()
+            if best:
+                results["osm_geocoding"] = {
+                    "address": best.formatted_address,
+                    "country": best.country,
+                    "state": best.state,
+                    "city": best.city,
+                    "status": "success",
+                }
+                console.print(f" ✓ {best.country or 'Unknown'}", style="green")
+            else:
+                results["osm_geocoding"] = {"status": "no_results"}
+                console.print(" ⚠ No results", style="yellow")
+        else:
+            results["osm_geocoding"] = {"status": "failed", "error": geo_result.error}
+            console.print(f" ✗ {geo_result.error}", style="red")
+    except Exception as e:
+        results["osm_geocoding"] = {"status": "error", "error": str(e)}
+        console.print(f" ✗ Error: {e}", style="red")
+
+    # Rate limiting for OSM
+    time.sleep(1.0)
+
+    return results
+
+
+def display_results_table(all_results: list[dict[str, Any]]) -> None:
+    """Display results in a formatted table."""
+    console.print("\n[bold]Summary Table:[/bold]")
+
+    # Elevation table
+    table = Table(show_header=True, header_style="bold blue", title="Elevation Results")
+    table.add_column("Location", style="cyan")
+    table.add_column("Google (m)", justify="right")
+    table.add_column("OSM (m)", justify="right")
+    table.add_column("Difference (m)", justify="right")
+
+    for result in all_results:
+        google_elev = result.get("google_elevation", {})
+        osm_elev = result.get("osm_elevation", {})
+
+        google_val = google_elev.get("elevation_m", "N/A")
+        osm_val = osm_elev.get("elevation_m", "N/A")
+
+        google_str = (
+            f"{google_val:.2f}"
+            if isinstance(google_val, int | float)
+            else str(google_val)
+        )
+        osm_str = f"{osm_val:.2f}" if isinstance(osm_val, int | float) else str(osm_val)
+
+        diff_str = "-"
+        if isinstance(google_val, int | float) and isinstance(osm_val, int | float):
+            diff = abs(google_val - osm_val)
+            diff_str = f"{diff:.2f}"
+
+        table.add_row(result["name"], google_str, osm_str, diff_str)
+
+    console.print(table)
+
+    # Geocoding table
+    table = Table(show_header=True, header_style="bold blue", title="Geocoding Results")
+    table.add_column("Location", style="cyan")
+    table.add_column("Google Country", justify="left")
+    table.add_column("OSM Country", justify="left")
+    table.add_column("Match", justify="center")
+
+    for result in all_results:
+        google_geo = result.get("google_geocoding", {})
+        osm_geo = result.get("osm_geocoding", {})
+
+        google_country = google_geo.get("country", "N/A")
+        osm_country = osm_geo.get("country", "N/A")
+
+        match = (
+            "✓" if google_country == osm_country and google_country != "N/A" else "✗"
+        )
+        match_style = "green" if match == "✓" else "red"
+
+        table.add_row(
+            result["name"],
+            google_country,
+            osm_country,
+            f"[{match_style}]{match}[/{match_style}]",
+        )
+
+    console.print(table)
+
+
+def main() -> None:
+    """Main entry point."""
+    console.print(
+        Panel.fit(
+            "[bold green]Geocoding Services Comprehensive Demo[/bold green]\n"
+            "Testing Google and OSM providers for Elevation and Reverse Geocoding",
+            border_style="green",
+        )
+    )
+
+    # Check for Google API key
+    if os.getenv("GOOGLE_MAIN_API_KEY"):
+        console.print("[green]✓ Google API key found[/green]")
+    else:
+        console.print("[red]✗ Google API key not found - Google tests will fail[/red]")
+        console.print(
+            "Set GOOGLE_MAIN_API_KEY environment variable to enable Google APIs"
+        )
+
+    all_results = []
+
+    for location in TEST_LOCATIONS:
+        console.print(f"\n[bold yellow]Testing: {location['name']}[/bold yellow]")
+        console.print(f"Coordinates: {location['lat']:.4f}, {location['lon']:.4f}")
+
+        # Test Google APIs
+        console.print("[bold]Google APIs:[/bold]")
+        google_results = test_google_apis(
+            location["lat"], location["lon"], location["name"]
+        )
+
+        # Test OSM APIs
+        console.print("[bold]OSM APIs:[/bold]")
+        osm_results = test_osm_apis(location["lat"], location["lon"], location["name"])
+
+        # Combine results
+        combined = {**google_results, **osm_results}
+        all_results.append(combined)
+
+        # Brief pause between locations
+        time.sleep(0.5)
+
+    # Display summary
+    display_results_table(all_results)
+
+    # Save results to JSON
+    output_file = "geocoding_demo_results.json"
+    with open(output_file, "w") as f:
+        json.dump(all_results, f, indent=2, default=str)
+    console.print(f"\n[green]Results saved to {output_file}[/green]")
+
+    console.print("\n[bold green]Demo completed successfully![/bold green]")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Demo interrupted by user[/yellow]")
+        sys.exit(0)
+    except Exception as e:
+        console.print(f"\n[red]Error: {e}[/red]")
+        raise

--- a/biosample_enricher/reverse_geocoding/__init__.py
+++ b/biosample_enricher/reverse_geocoding/__init__.py
@@ -1,0 +1,11 @@
+"""Reverse geocoding module for biosample enrichment."""
+
+from .providers.google import GoogleReverseGeocodingProvider
+from .providers.osm import OSMReverseGeocodingProvider
+from .service import ReverseGeocodingService
+
+__all__ = [
+    "ReverseGeocodingService",
+    "OSMReverseGeocodingProvider",
+    "GoogleReverseGeocodingProvider",
+]

--- a/biosample_enricher/reverse_geocoding/providers/__init__.py
+++ b/biosample_enricher/reverse_geocoding/providers/__init__.py
@@ -1,0 +1,12 @@
+"""Reverse geocoding provider implementations."""
+
+from .base import BaseReverseGeocodingProvider, ReverseGeocodingProvider
+from .google import GoogleReverseGeocodingProvider
+from .osm import OSMReverseGeocodingProvider
+
+__all__ = [
+    "BaseReverseGeocodingProvider",
+    "ReverseGeocodingProvider",
+    "OSMReverseGeocodingProvider",
+    "GoogleReverseGeocodingProvider",
+]

--- a/biosample_enricher/reverse_geocoding/providers/base.py
+++ b/biosample_enricher/reverse_geocoding/providers/base.py
@@ -1,16 +1,16 @@
-"""Base class and protocol for elevation providers."""
+"""Base class and protocol for reverse geocoding providers."""
 
 from abc import ABC, abstractmethod
 from typing import Protocol
 
 from ...logging_config import get_logger
-from ...models import FetchResult
+from ...reverse_geocoding_models import ReverseGeocodeFetchResult
 
 logger = get_logger(__name__)
 
 
-class ElevationProvider(Protocol):
-    """Protocol defining the interface for elevation providers."""
+class ReverseGeocodingProvider(Protocol):
+    """Protocol defining the interface for reverse geocoding providers."""
 
     name: str
     endpoint: str
@@ -24,9 +24,11 @@ class ElevationProvider(Protocol):
         read_from_cache: bool = True,
         write_to_cache: bool = True,
         timeout_s: float = 20.0,
-    ) -> FetchResult:
+        language: str = "en",
+        limit: int = 10,
+    ) -> ReverseGeocodeFetchResult:
         """
-        Fetch elevation data for the given coordinates.
+        Fetch reverse geocoding data for the given coordinates.
 
         Args:
             lat: Latitude in decimal degrees
@@ -34,15 +36,17 @@ class ElevationProvider(Protocol):
             read_from_cache: Whether to read from cache
             write_to_cache: Whether to write to cache
             timeout_s: Request timeout in seconds
+            language: Language code for results (ISO 639-1)
+            limit: Maximum number of results to return
 
         Returns:
-            Fetch result with elevation data
+            Fetch result with reverse geocoding data
         """
         ...
 
 
-class BaseElevationProvider(ABC):
-    """Base implementation for elevation providers."""
+class BaseReverseGeocodingProvider(ABC):
+    """Base implementation for reverse geocoding providers."""
 
     def __init__(self, name: str, endpoint: str, api_version: str = "v1") -> None:
         """
@@ -67,9 +71,11 @@ class BaseElevationProvider(ABC):
         read_from_cache: bool = True,
         write_to_cache: bool = True,
         timeout_s: float = 20.0,
-    ) -> FetchResult:
+        language: str = "en",
+        limit: int = 10,
+    ) -> ReverseGeocodeFetchResult:
         """
-        Fetch elevation data for the given coordinates.
+        Fetch reverse geocoding data for the given coordinates.
 
         Args:
             lat: Latitude in decimal degrees
@@ -77,25 +83,31 @@ class BaseElevationProvider(ABC):
             read_from_cache: Whether to read from cache
             write_to_cache: Whether to write to cache
             timeout_s: Request timeout in seconds
+            language: Language code for results (ISO 639-1)
+            limit: Maximum number of results to return
 
         Returns:
-            Fetch result with elevation data
+            Fetch result with reverse geocoding data
         """
         pass
 
-    def _create_cache_key(self, lat: float, lon: float) -> str:
+    def _create_cache_key(
+        self, lat: float, lon: float, language: str = "en", limit: int = 10
+    ) -> str:
         """
-        Create a cache key for the given coordinates.
+        Create a cache key for the given coordinates and parameters.
 
         Args:
             lat: Latitude in decimal degrees
             lon: Longitude in decimal degrees
+            language: Language code
+            limit: Result limit
 
         Returns:
             Cache key string
         """
         # Canonicalize coordinates to 6 decimal places
-        return f"{self.name}:{lat:.6f},{lon:.6f}"
+        return f"{self.name}:reverse:{lat:.6f},{lon:.6f}:{language}:{limit}"
 
     def _validate_coordinates(self, lat: float, lon: float) -> None:
         """

--- a/biosample_enricher/reverse_geocoding/providers/google.py
+++ b/biosample_enricher/reverse_geocoding/providers/google.py
@@ -1,0 +1,454 @@
+"""Google Geocoding API reverse geocoding provider."""
+
+import os
+import time
+from typing import Any
+
+from ...http_cache import request
+from ...logging_config import get_logger
+from ...reverse_geocoding_models import (
+    AddressComponent,
+    AddressComponentType,
+    BoundingBox,
+    PlaceType,
+    ReverseGeocodeFetchResult,
+    ReverseGeocodeLocation,
+    ReverseGeocodeProvider,
+    ReverseGeocodeResult,
+)
+from .base import BaseReverseGeocodingProvider
+
+logger = get_logger(__name__)
+
+
+class GoogleReverseGeocodingProvider(BaseReverseGeocodingProvider):
+    """Provider for Google Geocoding API reverse geocoding."""
+
+    # Mapping of Google address component types to our types
+    COMPONENT_TYPE_MAPPING = {
+        "country": AddressComponentType.COUNTRY,
+        "administrative_area_level_1": AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1,
+        "administrative_area_level_2": AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_2,
+        "administrative_area_level_3": AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3,
+        "administrative_area_level_4": AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_4,
+        "administrative_area_level_5": AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_5,
+        "locality": AddressComponentType.LOCALITY,
+        "sublocality": AddressComponentType.SUBLOCALITY,
+        "sublocality_level_1": AddressComponentType.SUBLOCALITY_LEVEL_1,
+        "sublocality_level_2": AddressComponentType.SUBLOCALITY_LEVEL_2,
+        "sublocality_level_3": AddressComponentType.SUBLOCALITY_LEVEL_3,
+        "sublocality_level_4": AddressComponentType.SUBLOCALITY_LEVEL_4,
+        "sublocality_level_5": AddressComponentType.SUBLOCALITY_LEVEL_5,
+        "route": AddressComponentType.ROUTE,
+        "street_number": AddressComponentType.STREET_NUMBER,
+        "street_address": AddressComponentType.STREET_ADDRESS,
+        "premise": AddressComponentType.PREMISE,
+        "subpremise": AddressComponentType.SUBPREMISE,
+        "postal_code": AddressComponentType.POSTAL_CODE,
+        "postal_code_prefix": AddressComponentType.POSTAL_CODE_PREFIX,
+        "postal_code_suffix": AddressComponentType.POSTAL_CODE_SUFFIX,
+        "natural_feature": AddressComponentType.NATURAL_FEATURE,
+        "park": AddressComponentType.PARK,
+        "point_of_interest": AddressComponentType.POINT_OF_INTEREST,
+        "establishment": AddressComponentType.ESTABLISHMENT,
+        "neighborhood": AddressComponentType.NEIGHBORHOOD,
+        "colloquial_area": AddressComponentType.COLLOQUIAL_AREA,
+        "plus_code": AddressComponentType.PLUS_CODE,
+        "political": AddressComponentType.POLITICAL,
+        "intersection": AddressComponentType.INTERSECTION,
+        "continent": AddressComponentType.CONTINENT,
+    }
+
+    def __init__(self, api_key: str | None = None) -> None:
+        """
+        Initialize Google Geocoding reverse geocoding provider.
+
+        Args:
+            api_key: Google API key (if None, reads from GOOGLE_MAIN_API_KEY env var)
+        """
+        super().__init__(
+            name="google_geocoding",
+            endpoint="https://maps.googleapis.com/maps/api/geocode/json",
+            api_version="v1",
+        )
+
+        self.api_key = api_key or os.getenv("GOOGLE_MAIN_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Google API key required. Set GOOGLE_MAIN_API_KEY environment variable "
+                "or pass api_key parameter."
+            )
+
+        logger.info("Google Geocoding provider initialized")
+
+    def fetch(
+        self,
+        lat: float,
+        lon: float,
+        *,
+        read_from_cache: bool = True,
+        write_to_cache: bool = True,
+        timeout_s: float = 20.0,
+        language: str = "en",
+        limit: int = 10,
+    ) -> ReverseGeocodeFetchResult:
+        """
+        Fetch reverse geocoding data from Google Geocoding API.
+
+        Args:
+            lat: Latitude in decimal degrees
+            lon: Longitude in decimal degrees
+            read_from_cache: Whether to read from cache
+            write_to_cache: Whether to write to cache
+            timeout_s: Request timeout in seconds
+            language: Language code for results
+            limit: Maximum number of results (Google may return more)
+
+        Returns:
+            Fetch result with reverse geocoding data
+        """
+        self._validate_coordinates(lat, lon)
+
+        logger.debug(
+            f"Fetching reverse geocoding from Google API: {lat:.6f}, {lon:.6f}"
+        )
+
+        start_time = time.time()
+        try:
+            # Prepare request parameters
+            params = {
+                "latlng": f"{lat},{lon}",
+                "key": self.api_key,
+                "language": language,
+                # Google doesn't have a direct limit param, but we can use result_type
+                # to filter results
+            }
+
+            # Make request using cached HTTP client
+            response = request(
+                "GET",
+                self.endpoint,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
+                params=params,
+                timeout=timeout_s,
+            )
+
+            response_time_ms = (time.time() - start_time) * 1000
+            response.raise_for_status()
+            data = response.json()
+
+            # Check for cache hit (from_cache attribute may not exist)
+            cache_hit = getattr(response, "from_cache", False)
+            return self._parse_response(
+                lat, lon, data, response_time_ms, cache_hit=cache_hit, limit=limit
+            )
+
+        except Exception as e:
+            logger.error(f"Google Geocoding API error: {e}")
+            return ReverseGeocodeFetchResult(ok=False, error=str(e), raw={})
+
+    def _parse_response(
+        self,
+        lat: float,
+        lon: float,
+        data: dict[str, Any],
+        response_time_ms: float,
+        cache_hit: bool,
+        limit: int,
+    ) -> ReverseGeocodeFetchResult:
+        """
+        Parse Google Geocoding API response.
+
+        Args:
+            lat: Requested latitude
+            lon: Requested longitude
+            data: API response data
+            response_time_ms: Response time in milliseconds
+            cache_hit: Whether response was from cache
+            limit: Maximum number of results to return
+
+        Returns:
+            Parsed fetch result
+        """
+        try:
+            # Check API status
+            status = data.get("status")
+            error_message = data.get("error_message")
+
+            if status not in ["OK", "ZERO_RESULTS"]:
+                error_msg = error_message or f"API returned status: {status}"
+                logger.warning(f"Google API error: {error_msg}")
+                return ReverseGeocodeFetchResult(ok=False, error=error_msg, raw=data)
+
+            # Extract results
+            results = data.get("results", [])
+
+            # Parse locations (limit to requested number)
+            locations = []
+            for i, result in enumerate(results[:limit]):
+                location = self._parse_location(result, lat, lon)
+                if location:
+                    # Add confidence based on order (first result is most confident)
+                    location.confidence = max(0.5, 1.0 - (i * 0.1))
+                    locations.append(location)
+
+            provider = ReverseGeocodeProvider(
+                name=self.name,
+                endpoint=self.endpoint,
+                api_version=self.api_version,
+                rate_limit=50,  # Google allows up to 50 QPS
+            )
+
+            result = ReverseGeocodeResult(
+                query_lat=lat,
+                query_lon=lon,
+                locations=locations,
+                provider=provider,
+                status=status,
+                error_message=error_message,
+                response_time_ms=response_time_ms,
+                cache_hit=cache_hit,
+                raw_response=data,
+            )
+
+            return ReverseGeocodeFetchResult(ok=True, result=result, raw=data)
+
+        except Exception as e:
+            logger.error(f"Error parsing Google response: {e}")
+            return ReverseGeocodeFetchResult(
+                ok=False, error=f"Response parsing error: {e}", raw=data
+            )
+
+    def _parse_location(
+        self, result: dict[str, Any], query_lat: float, query_lon: float
+    ) -> ReverseGeocodeLocation | None:
+        """
+        Parse a single location from Google response.
+
+        Args:
+            result: Single result from Google API
+            query_lat: Query latitude
+            query_lon: Query longitude
+
+        Returns:
+            Parsed location or None if invalid
+        """
+        try:
+            # Extract basic information
+            formatted_address = result.get("formatted_address", "")
+            place_id = result.get("place_id", "")
+
+            # Parse geometry
+            geometry = result.get("geometry", {})
+            location = geometry.get("location", {})
+            lat = location.get("lat", query_lat)
+            lon = location.get("lng", query_lon)
+
+            # Parse bounding box from viewport
+            bounding_box = None
+            viewport = geometry.get("viewport")
+            if viewport:
+                northeast = viewport.get("northeast", {})
+                southwest = viewport.get("southwest", {})
+                if northeast and southwest:
+                    bounding_box = BoundingBox(
+                        north=northeast.get("lat", lat),
+                        south=southwest.get("lat", lat),
+                        east=northeast.get("lng", lon),
+                        west=southwest.get("lng", lon),
+                    )
+
+            # Parse address components
+            address_components = result.get("address_components", [])
+            components = self._parse_address_components(address_components)
+
+            # Extract common fields from components
+            country = None
+            country_code = None
+            state = None
+            state_code = None
+            county = None
+            city = None
+            suburb = None
+            postcode = None
+            road = None
+            house_number = None
+
+            for comp in address_components:
+                types = comp.get("types", [])
+                long_name = comp.get("long_name", "")
+                short_name = comp.get("short_name", "")
+
+                if "country" in types:
+                    country = long_name
+                    country_code = short_name.upper()
+                elif "administrative_area_level_1" in types:
+                    state = long_name
+                    state_code = short_name
+                elif "administrative_area_level_2" in types:
+                    county = long_name
+                elif "locality" in types:
+                    city = long_name
+                elif "sublocality" in types or "sublocality_level_1" in types:
+                    suburb = long_name
+                elif "postal_code" in types:
+                    postcode = long_name
+                elif "route" in types:
+                    road = long_name
+                elif "street_number" in types:
+                    house_number = long_name
+
+            # Determine place type from Google types
+            place_type = self._determine_place_type(result.get("types", []))
+
+            # Calculate distance from query point
+            distance_m = self._calculate_distance(query_lat, query_lon, lat, lon)
+
+            return ReverseGeocodeLocation(
+                formatted_address=formatted_address,
+                display_name=formatted_address,
+                components=components,
+                country=country,
+                country_code=country_code,
+                state=state,
+                state_code=state_code,
+                county=county,
+                city=city,
+                suburb=suburb,
+                postcode=postcode,
+                road=road,
+                house_number=house_number,
+                house_name=None,  # Google doesn't provide house names
+                place_type=place_type,
+                place_rank=None,  # Google doesn't provide place rank
+                importance=None,  # Google doesn't provide importance score
+                lat=lat,
+                lon=lon,
+                bounding_box=bounding_box,
+                place_id=place_id,
+                osm_id=None,  # Google doesn't provide OSM IDs
+                osm_type=None,
+                wikidata_id=None,  # Google doesn't provide Wikidata IDs
+                wikipedia_url=None,
+                licence="Google Maps Platform Terms of Service",
+                attribution="Google",
+                distance_m=distance_m,
+            )
+
+        except Exception as e:
+            import traceback
+
+            logger.warning(f"Error parsing location result: {e}")
+            logger.debug(f"Traceback: {traceback.format_exc()}")
+            return None
+
+    def _parse_address_components(
+        self, components: list[dict[str, Any]]
+    ) -> list[AddressComponent]:
+        """
+        Parse Google address components into structured components.
+
+        Args:
+            components: List of address components from Google
+
+        Returns:
+            List of parsed address components
+        """
+        parsed_components = []
+
+        for comp in components:
+            types = comp.get("types", [])
+            long_name = comp.get("long_name", "")
+            short_name = comp.get("short_name", "")
+
+            # Find the first matching type
+            for google_type in types:
+                if google_type in self.COMPONENT_TYPE_MAPPING:
+                    component_type = self.COMPONENT_TYPE_MAPPING[google_type]
+                    parsed_components.append(
+                        AddressComponent(
+                            type=component_type,
+                            short_name=short_name,
+                            long_name=long_name,
+                            confidence=1.0,  # Google doesn't provide confidence scores
+                        )
+                    )
+                    break  # Only use the first matching type
+
+        return parsed_components
+
+    def _determine_place_type(self, types: list[str]) -> PlaceType | None:
+        """
+        Determine place type from Google types.
+
+        Args:
+            types: List of Google place types
+
+        Returns:
+            Place type or None
+        """
+        # Map Google types to our PlaceType enum
+        type_mapping = {
+            "establishment": PlaceType.ESTABLISHMENT,
+            "point_of_interest": PlaceType.POINT_OF_INTEREST,
+            "natural_feature": PlaceType.NATURAL,
+            "park": PlaceType.PARK,
+            "route": PlaceType.HIGHWAY,
+            "street_address": PlaceType.BUILDING,
+            "premise": PlaceType.BUILDING,
+            "airport": PlaceType.AEROWAY,
+            "train_station": PlaceType.RAILWAY,
+            "bus_station": PlaceType.AMENITY,
+            "tourist_attraction": PlaceType.TOURISM,
+            "place_of_worship": PlaceType.AMENITY,
+            "store": PlaceType.SHOP,
+            "restaurant": PlaceType.AMENITY,
+            "hospital": PlaceType.AMENITY,
+            "school": PlaceType.AMENITY,
+            "university": PlaceType.AMENITY,
+        }
+
+        for google_type in types:
+            if google_type in type_mapping:
+                return type_mapping[google_type]
+
+        # Default to PLACE if we have location-based types
+        if any(
+            t in ["political", "locality", "administrative_area_level_1"] for t in types
+        ):
+            return PlaceType.PLACE
+
+        return PlaceType.OTHER
+
+    def _calculate_distance(
+        self, lat1: float, lon1: float, lat2: float, lon2: float
+    ) -> float:
+        """
+        Calculate distance between two points in meters using Haversine formula.
+
+        Args:
+            lat1: First point latitude
+            lon1: First point longitude
+            lat2: Second point latitude
+            lon2: Second point longitude
+
+        Returns:
+            Distance in meters
+        """
+        from math import cos, radians, sin
+
+        R = 6371000  # Earth's radius in meters
+
+        lat1_rad = radians(lat1)
+        lat2_rad = radians(lat2)
+        delta_lat = radians(lat2 - lat1)
+        delta_lon = radians(lon2 - lon1)
+
+        a = (
+            sin(delta_lat / 2) ** 2
+            + cos(lat1_rad) * cos(lat2_rad) * sin(delta_lon / 2) ** 2
+        )
+        c = 2 * (a**0.5)
+
+        return float(R * c)

--- a/biosample_enricher/reverse_geocoding/providers/osm.py
+++ b/biosample_enricher/reverse_geocoding/providers/osm.py
@@ -1,0 +1,407 @@
+"""OpenStreetMap Nominatim reverse geocoding provider."""
+
+import time
+from typing import Any
+
+from ...http_cache import request
+from ...logging_config import get_logger
+from ...reverse_geocoding_models import (
+    AddressComponent,
+    AddressComponentType,
+    BoundingBox,
+    PlaceType,
+    ReverseGeocodeFetchResult,
+    ReverseGeocodeLocation,
+    ReverseGeocodeProvider,
+    ReverseGeocodeResult,
+)
+from .base import BaseReverseGeocodingProvider
+
+logger = get_logger(__name__)
+
+
+class OSMReverseGeocodingProvider(BaseReverseGeocodingProvider):
+    """Provider for OpenStreetMap Nominatim reverse geocoding API."""
+
+    def __init__(
+        self,
+        endpoint: str = "https://nominatim.openstreetmap.org/reverse",
+        user_agent: str = "biosample-enricher/1.0",
+    ) -> None:
+        """
+        Initialize OSM Nominatim reverse geocoding provider.
+
+        Args:
+            endpoint: API endpoint URL (defaults to public Nominatim)
+            user_agent: User agent string for API requests
+        """
+        super().__init__(name="osm_nominatim", endpoint=endpoint, api_version="v1")
+        self.user_agent = user_agent
+        self.last_request_time = 0.0
+        self.min_request_interval = 1.0  # Respect Nominatim rate limit (1 req/sec)
+        logger.info(f"OSM Nominatim provider initialized: {endpoint}")
+
+    def fetch(
+        self,
+        lat: float,
+        lon: float,
+        *,
+        read_from_cache: bool = True,
+        write_to_cache: bool = True,
+        timeout_s: float = 20.0,
+        language: str = "en",
+        limit: int = 10,
+    ) -> ReverseGeocodeFetchResult:
+        """
+        Fetch reverse geocoding data from OSM Nominatim API.
+
+        Args:
+            lat: Latitude in decimal degrees
+            lon: Longitude in decimal degrees
+            read_from_cache: Whether to read from cache
+            write_to_cache: Whether to write to cache
+            timeout_s: Request timeout in seconds
+            language: Language code for results
+            limit: Maximum number of results to return
+
+        Returns:
+            Fetch result with reverse geocoding data
+        """
+        self._validate_coordinates(lat, lon)
+
+        # Enforce rate limiting for public Nominatim
+        if "nominatim.openstreetmap.org" in self.endpoint:
+            current_time = time.time()
+            time_since_last = current_time - self.last_request_time
+            if time_since_last < self.min_request_interval:
+                sleep_time = self.min_request_interval - time_since_last
+                logger.debug(f"Rate limiting: sleeping for {sleep_time:.2f}s")
+                time.sleep(sleep_time)
+            self.last_request_time = time.time()
+
+        logger.debug(f"Fetching reverse geocoding from Nominatim: {lat:.6f}, {lon:.6f}")
+
+        start_time = time.time()
+        try:
+            # Prepare request parameters
+            params = {
+                "lat": str(lat),
+                "lon": str(lon),
+                "format": "jsonv2",
+                "addressdetails": "1",
+                "extratags": "1",
+                "namedetails": "1",
+                "limit": str(limit),
+                "accept-language": language,
+            }
+
+            headers = {
+                "User-Agent": self.user_agent,
+                "Accept": "application/json",
+            }
+
+            # Make request using cached HTTP client
+            response = request(
+                "GET",
+                self.endpoint,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
+                params=params,
+                headers=headers,
+                timeout=timeout_s,
+            )
+
+            response_time_ms = (time.time() - start_time) * 1000
+            response.raise_for_status()
+            data = response.json()
+
+            # Check for cache hit (from_cache attribute may not exist)
+            cache_hit = getattr(response, "from_cache", False)
+            return self._parse_response(
+                lat, lon, data, response_time_ms, cache_hit=cache_hit
+            )
+
+        except Exception as e:
+            logger.error(f"OSM Nominatim API error: {e}")
+            return ReverseGeocodeFetchResult(ok=False, error=str(e), raw={})
+
+    def _parse_response(
+        self,
+        lat: float,
+        lon: float,
+        data: dict[str, Any] | list[dict[str, Any]],
+        response_time_ms: float,
+        cache_hit: bool,
+    ) -> ReverseGeocodeFetchResult:
+        """
+        Parse OSM Nominatim API response.
+
+        Args:
+            lat: Requested latitude
+            lon: Requested longitude
+            data: API response data
+            response_time_ms: Response time in milliseconds
+            cache_hit: Whether response was from cache
+
+        Returns:
+            Parsed fetch result
+        """
+        try:
+            # Nominatim returns a single object or array depending on limit
+            # Convert single result to list for uniform processing
+            data_list = [data] if isinstance(data, dict) else data
+
+            locations = []
+            for item in data_list:
+                location = self._parse_location(item)
+                if location:
+                    locations.append(location)
+
+            if not locations:
+                return ReverseGeocodeFetchResult(
+                    ok=False, error="No locations found", raw={"response": data}
+                )
+
+            provider = ReverseGeocodeProvider(
+                name=self.name,
+                endpoint=self.endpoint,
+                api_version=self.api_version,
+                rate_limit=1,  # 1 request per second for public Nominatim
+            )
+
+            result = ReverseGeocodeResult(
+                query_lat=lat,
+                query_lon=lon,
+                locations=locations,
+                provider=provider,
+                status="OK",
+                response_time_ms=response_time_ms,
+                cache_hit=cache_hit,
+                raw_response={"results": data},
+            )
+
+            return ReverseGeocodeFetchResult(
+                ok=True, result=result, raw={"response": data}
+            )
+
+        except Exception as e:
+            logger.error(f"Error parsing Nominatim response: {e}")
+            return ReverseGeocodeFetchResult(
+                ok=False, error=f"Response parsing error: {e}", raw={"response": data}
+            )
+
+    def _parse_location(self, item: dict[str, Any]) -> ReverseGeocodeLocation | None:
+        """
+        Parse a single location from Nominatim response.
+
+        Args:
+            item: Single location item from response
+
+        Returns:
+            Parsed location or None if invalid
+        """
+        try:
+            # Extract basic information
+            display_name = item.get("display_name", "")
+            place_id = str(item.get("place_id", ""))
+            osm_type = item.get("osm_type")
+            osm_id = str(item.get("osm_id", ""))
+
+            # Parse coordinates
+            lat = float(item.get("lat", 0))
+            lon = float(item.get("lon", 0))
+
+            # Parse bounding box if available
+            bounding_box = None
+            if "boundingbox" in item and len(item["boundingbox"]) == 4:
+                bbox = item["boundingbox"]
+                bounding_box = BoundingBox(
+                    south=float(bbox[0]),
+                    north=float(bbox[1]),
+                    west=float(bbox[2]),
+                    east=float(bbox[3]),
+                )
+
+            # Parse address components
+            address = item.get("address", {})
+            components = self._parse_address_components(address)
+
+            # Extract common fields
+            country = address.get("country")
+            country_code = address.get("country_code", "").upper()
+            state = (
+                address.get("state") or address.get("province") or address.get("region")
+            )
+            county = address.get("county") or address.get("district")
+            city = (
+                address.get("city")
+                or address.get("town")
+                or address.get("village")
+                or address.get("municipality")
+            )
+            suburb = (
+                address.get("suburb")
+                or address.get("neighbourhood")
+                or address.get("quarter")
+            )
+            postcode = address.get("postcode") or address.get("postal_code")
+            road = address.get("road") or address.get("street")
+            house_number = address.get("house_number")
+            house_name = address.get("house_name") or address.get("building")
+
+            # Determine place type
+            place_type = self._determine_place_type(item)
+
+            # Parse extra tags
+            extratags = item.get("extratags", {})
+            wikidata_id = extratags.get("wikidata")
+            wikipedia = extratags.get("wikipedia")
+            wikipedia_url = (
+                f"https://wikipedia.org/wiki/{wikipedia}" if wikipedia else None
+            )
+
+            # Calculate importance and confidence
+            importance = item.get("importance")
+            if importance is not None:
+                importance = float(importance)
+                confidence = min(1.0, importance)  # Normalize to 0-1
+            else:
+                confidence = None
+
+            # Get place rank
+            place_rank = item.get("place_rank")
+            if place_rank is not None:
+                place_rank = int(place_rank)
+
+            return ReverseGeocodeLocation(
+                formatted_address=display_name,
+                display_name=display_name,
+                components=components,
+                country=country,
+                country_code=country_code,
+                state=state,
+                state_code=None,  # OSM doesn't provide state codes
+                county=county,
+                city=city,
+                suburb=suburb,
+                postcode=postcode,
+                road=road,
+                house_number=house_number,
+                house_name=house_name,
+                place_type=place_type,
+                place_rank=place_rank,
+                importance=importance,
+                lat=lat,
+                lon=lon,
+                bounding_box=bounding_box,
+                place_id=place_id,
+                osm_id=osm_id,
+                osm_type=osm_type,
+                wikidata_id=wikidata_id,
+                wikipedia_url=wikipedia_url,
+                licence="Data © OpenStreetMap contributors, ODbL 1.0",
+                attribution="OpenStreetMap",
+                confidence=confidence,
+            )
+
+        except Exception as e:
+            logger.warning(f"Error parsing location item: {e}")
+            return None
+
+    def _parse_address_components(
+        self, address: dict[str, Any]
+    ) -> list[AddressComponent]:
+        """
+        Parse address dictionary into structured components.
+
+        Args:
+            address: Address dictionary from Nominatim
+
+        Returns:
+            List of address components
+        """
+        components = []
+
+        # Mapping of OSM address keys to component types
+        mappings = [
+            ("country", AddressComponentType.COUNTRY),
+            ("state", AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1),
+            ("province", AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1),
+            ("region", AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1),
+            ("county", AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_2),
+            ("district", AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_3),
+            ("city", AddressComponentType.LOCALITY),
+            ("town", AddressComponentType.LOCALITY),
+            ("village", AddressComponentType.LOCALITY),
+            ("municipality", AddressComponentType.LOCALITY),
+            ("suburb", AddressComponentType.SUBLOCALITY),
+            ("neighbourhood", AddressComponentType.NEIGHBORHOOD),
+            ("quarter", AddressComponentType.NEIGHBORHOOD),
+            ("road", AddressComponentType.ROUTE),
+            ("street", AddressComponentType.ROUTE),
+            ("house_number", AddressComponentType.STREET_NUMBER),
+            ("postcode", AddressComponentType.POSTAL_CODE),
+            ("postal_code", AddressComponentType.POSTAL_CODE),
+        ]
+
+        for key, component_type in mappings:
+            value = address.get(key)
+            if value:
+                components.append(
+                    AddressComponent(
+                        type=component_type,
+                        short_name=str(value),
+                        long_name=str(value),
+                    )
+                )
+
+        return components
+
+    def _determine_place_type(self, item: dict[str, Any]) -> PlaceType | None:
+        """
+        Determine place type from OSM data.
+
+        Args:
+            item: Location item from Nominatim
+
+        Returns:
+            Place type or None
+        """
+        # Check the 'type' field
+        osm_type = item.get("type", "").lower()
+
+        # Map common OSM types to our PlaceType enum
+        type_mapping = {
+            "building": PlaceType.BUILDING,
+            "house": PlaceType.HOUSE,
+            "amenity": PlaceType.AMENITY,
+            "shop": PlaceType.SHOP,
+            "tourism": PlaceType.TOURISM,
+            "historic": PlaceType.HISTORIC,
+            "leisure": PlaceType.LEISURE,
+            "natural": PlaceType.NATURAL,
+            "landuse": PlaceType.LANDUSE,
+            "waterway": PlaceType.WATERWAY,
+            "highway": PlaceType.HIGHWAY,
+            "railway": PlaceType.RAILWAY,
+            "aeroway": PlaceType.AEROWAY,
+            "boundary": PlaceType.BOUNDARY,
+            "place": PlaceType.PLACE,
+            "office": PlaceType.OFFICE,
+            "emergency": PlaceType.EMERGENCY,
+            "military": PlaceType.MILITARY,
+            "craft": PlaceType.CRAFT,
+            "man_made": PlaceType.MAN_MADE,
+        }
+
+        for key, place_type in type_mapping.items():
+            if key in osm_type:
+                return place_type
+
+        # Check category field
+        category = item.get("category", "").lower()
+        for key, place_type in type_mapping.items():
+            if key in category:
+                return place_type
+
+        return PlaceType.OTHER

--- a/biosample_enricher/reverse_geocoding/service.py
+++ b/biosample_enricher/reverse_geocoding/service.py
@@ -1,0 +1,266 @@
+"""Reverse geocoding service for coordinating multiple providers."""
+
+from typing import Any
+
+from ..logging_config import get_logger
+from ..reverse_geocoding_models import ReverseGeocodeResult
+from .providers.base import ReverseGeocodingProvider
+from .providers.google import GoogleReverseGeocodingProvider
+from .providers.osm import OSMReverseGeocodingProvider
+
+logger = get_logger(__name__)
+
+
+class ReverseGeocodingService:
+    """Service for managing reverse geocoding providers."""
+
+    def __init__(self) -> None:
+        """Initialize the reverse geocoding service."""
+        self.providers: dict[str, ReverseGeocodingProvider] = {}
+        self._initialize_providers()
+
+    def _initialize_providers(self) -> None:
+        """Initialize available reverse geocoding providers."""
+        # Initialize OSM provider (always available)
+        try:
+            osm_provider = OSMReverseGeocodingProvider()
+            self.providers["osm"] = osm_provider
+            logger.info("Initialized OSM reverse geocoding provider")
+        except Exception as e:
+            logger.error(f"Failed to initialize OSM provider: {e}")
+
+        # Initialize Google provider if API key is available
+        try:
+            google_provider = GoogleReverseGeocodingProvider()
+            self.providers["google"] = google_provider
+            logger.info("Initialized Google reverse geocoding provider")
+        except ValueError as e:
+            logger.warning(f"Google provider not available: {e}")
+        except Exception as e:
+            logger.error(f"Failed to initialize Google provider: {e}")
+
+    def get_available_providers(self) -> list[str]:
+        """Get list of available provider names."""
+        return list(self.providers.keys())
+
+    def get_provider(self, name: str) -> ReverseGeocodingProvider | None:
+        """
+        Get a specific provider by name.
+
+        Args:
+            name: Provider name
+
+        Returns:
+            Provider instance or None if not found
+        """
+        return self.providers.get(name)
+
+    def reverse_geocode(
+        self,
+        lat: float,
+        lon: float,
+        provider: str | None = None,
+        *,
+        read_from_cache: bool = True,
+        write_to_cache: bool = True,
+        timeout_s: float = 20.0,
+        language: str = "en",
+        limit: int = 10,
+    ) -> ReverseGeocodeResult | None:
+        """
+        Perform reverse geocoding using specified or default provider.
+
+        Args:
+            lat: Latitude in decimal degrees
+            lon: Longitude in decimal degrees
+            provider: Provider name (None for auto-selection)
+            read_from_cache: Whether to read from cache
+            write_to_cache: Whether to write to cache
+            timeout_s: Request timeout in seconds
+            language: Language code for results
+            limit: Maximum number of results
+
+        Returns:
+            Reverse geocoding result or None if failed
+        """
+        # Select provider
+        if provider:
+            provider_instance = self.providers.get(provider)
+            if not provider_instance:
+                logger.error(f"Provider '{provider}' not found")
+                return None
+        else:
+            # Auto-select: prefer Google if available, else OSM
+            provider_instance = self.providers.get("google") or self.providers.get(
+                "osm"
+            )
+            if not provider_instance:
+                logger.error("No providers available")
+                return None
+
+        # Perform reverse geocoding
+        try:
+            logger.info(
+                f"Reverse geocoding {lat:.6f}, {lon:.6f} using {provider_instance.name}"
+            )
+
+            result = provider_instance.fetch(
+                lat,
+                lon,
+                read_from_cache=read_from_cache,
+                write_to_cache=write_to_cache,
+                timeout_s=timeout_s,
+                language=language,
+                limit=limit,
+            )
+
+            if result.ok and result.result:
+                return result.result
+            else:
+                logger.error(f"Reverse geocoding failed: {result.error}")
+                return None
+
+        except Exception as e:
+            logger.error(f"Error during reverse geocoding: {e}")
+            return None
+
+    def reverse_geocode_multiple(
+        self,
+        lat: float,
+        lon: float,
+        providers: list[str] | None = None,
+        *,
+        read_from_cache: bool = True,
+        write_to_cache: bool = True,
+        timeout_s: float = 20.0,
+        language: str = "en",
+        limit: int = 10,
+    ) -> dict[str, ReverseGeocodeResult]:
+        """
+        Perform reverse geocoding using multiple providers sequentially.
+
+        Args:
+            lat: Latitude in decimal degrees
+            lon: Longitude in decimal degrees
+            providers: List of provider names (None for all available)
+            read_from_cache: Whether to read from cache
+            write_to_cache: Whether to write to cache
+            timeout_s: Request timeout in seconds
+            language: Language code for results
+            limit: Maximum number of results per provider
+
+        Returns:
+            Dictionary mapping provider names to results
+        """
+        # Select providers
+        if providers:
+            provider_instances = {
+                name: self.providers[name]
+                for name in providers
+                if name in self.providers
+            }
+        else:
+            provider_instances = dict(self.providers.items())
+
+        if not provider_instances:
+            logger.error("No providers available")
+            return {}
+
+        # Execute providers sequentially
+        output: dict[str, ReverseGeocodeResult] = {}
+        for name, provider_instance in provider_instances.items():
+            try:
+                fetch_result = provider_instance.fetch(
+                    lat,
+                    lon,
+                    read_from_cache=read_from_cache,
+                    write_to_cache=write_to_cache,
+                    timeout_s=timeout_s,
+                    language=language,
+                    limit=limit,
+                )
+
+                if fetch_result.ok and fetch_result.result:
+                    output[name] = fetch_result.result
+                else:
+                    logger.error(f"Provider {name} failed: {fetch_result.error}")
+
+            except Exception as e:
+                logger.error(f"Provider {name} failed with exception: {e}")
+
+        return output
+
+    def compare_providers(
+        self,
+        lat: float,
+        lon: float,
+        *,
+        language: str = "en",
+        limit: int = 5,
+    ) -> dict[str, Any]:
+        """
+        Compare results from all available providers.
+
+        Args:
+            lat: Latitude in decimal degrees
+            lon: Longitude in decimal degrees
+            language: Language code for results
+            limit: Maximum number of results per provider
+
+        Returns:
+            Comparison dictionary with results and analysis
+        """
+        # Get results from all providers
+        results = self.reverse_geocode_multiple(
+            lat, lon, language=language, limit=limit
+        )
+
+        if not results:
+            return {"error": "No providers returned results"}
+
+        # Extract best matches from each provider
+        comparison: dict[str, Any] = {
+            "query": {"lat": lat, "lon": lon},
+            "providers": {},
+            "consensus": {},
+        }
+
+        # Process each provider's results
+        for provider_name, result in results.items():
+            best_match = result.get_best_match()
+            if best_match:
+                comparison["providers"][provider_name] = {
+                    "formatted_address": best_match.formatted_address,
+                    "country": best_match.country,
+                    "country_code": best_match.country_code,
+                    "state": best_match.state,
+                    "city": best_match.city,
+                    "postcode": best_match.postcode,
+                    "confidence": best_match.confidence,
+                    "distance_m": best_match.distance_m,
+                    "response_time_ms": result.response_time_ms,
+                    "cache_hit": result.cache_hit,
+                    "num_results": len(result.locations),
+                }
+
+        # Find consensus values (values that appear in multiple providers)
+        fields_to_compare = ["country", "country_code", "state", "city", "postcode"]
+        for field in fields_to_compare:
+            values: dict[str, list[str]] = {}
+            for provider_name, provider_data in comparison["providers"].items():
+                value = provider_data.get(field)
+                if value:
+                    if value not in values:
+                        values[value] = []
+                    values[value].append(provider_name)
+
+            # Find most common value
+            if values:
+                most_common = max(values.items(), key=lambda x: len(x[1]))
+                comparison["consensus"][field] = {
+                    "value": most_common[0],
+                    "providers": most_common[1],
+                    "agreement": len(most_common[1]) / len(results),
+                }
+
+        return comparison

--- a/biosample_enricher/reverse_geocoding_models.py
+++ b/biosample_enricher/reverse_geocoding_models.py
@@ -1,0 +1,288 @@
+"""
+Pydantic models for reverse geocoding data normalization and validation.
+
+Provides explicit schema definitions for standardized reverse geocoding results
+from OSM and Google providers.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AddressComponentType(str, Enum):
+    """Types of address components from various providers."""
+
+    # Common administrative levels
+    COUNTRY = "country"
+    ADMINISTRATIVE_AREA_LEVEL_1 = "administrative_area_level_1"  # State/Province
+    ADMINISTRATIVE_AREA_LEVEL_2 = "administrative_area_level_2"  # County
+    ADMINISTRATIVE_AREA_LEVEL_3 = "administrative_area_level_3"  # District
+    ADMINISTRATIVE_AREA_LEVEL_4 = "administrative_area_level_4"  # Ward
+    ADMINISTRATIVE_AREA_LEVEL_5 = "administrative_area_level_5"  # Sub-district
+
+    # Locality types
+    LOCALITY = "locality"  # City/Town
+    SUBLOCALITY = "sublocality"  # Neighborhood
+    SUBLOCALITY_LEVEL_1 = "sublocality_level_1"
+    SUBLOCALITY_LEVEL_2 = "sublocality_level_2"
+    SUBLOCALITY_LEVEL_3 = "sublocality_level_3"
+    SUBLOCALITY_LEVEL_4 = "sublocality_level_4"
+    SUBLOCALITY_LEVEL_5 = "sublocality_level_5"
+
+    # Street/Route types
+    ROUTE = "route"  # Street
+    STREET_NUMBER = "street_number"
+    STREET_ADDRESS = "street_address"
+    PREMISE = "premise"  # Building
+    SUBPREMISE = "subpremise"  # Unit/Apartment
+
+    # Postal codes
+    POSTAL_CODE = "postal_code"
+    POSTAL_CODE_PREFIX = "postal_code_prefix"
+    POSTAL_CODE_SUFFIX = "postal_code_suffix"
+
+    # Geographic features
+    NATURAL_FEATURE = "natural_feature"
+    PARK = "park"
+    POINT_OF_INTEREST = "point_of_interest"
+    ESTABLISHMENT = "establishment"
+    NEIGHBORHOOD = "neighborhood"
+    COLLOQUIAL_AREA = "colloquial_area"
+
+    # Other
+    PLUS_CODE = "plus_code"
+    POLITICAL = "political"
+    INTERSECTION = "intersection"
+    CONTINENT = "continent"
+    REGION = "region"
+    ISLAND = "island"
+    ARCHIPELAGO = "archipelago"
+
+
+class AddressComponent(BaseModel):
+    """Structured address component with type and value."""
+
+    type: AddressComponentType = Field(description="Type of address component")
+    short_name: str = Field(description="Short form of the component name")
+    long_name: str | None = Field(
+        default=None, description="Long form of the component name"
+    )
+    confidence: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Confidence score for this component"
+    )
+    osm_id: str | None = Field(
+        default=None, description="OpenStreetMap ID if available"
+    )
+    wikidata_id: str | None = Field(
+        default=None, description="Wikidata ID if available"
+    )
+
+
+class BoundingBox(BaseModel):
+    """Geographic bounding box."""
+
+    north: float = Field(ge=-90, le=90, description="Northern latitude bound")
+    south: float = Field(ge=-90, le=90, description="Southern latitude bound")
+    east: float = Field(ge=-180, le=180, description="Eastern longitude bound")
+    west: float = Field(ge=-180, le=180, description="Western longitude bound")
+
+
+class PlaceType(str, Enum):
+    """Types of places that can be returned."""
+
+    BUILDING = "building"
+    HOUSE = "house"
+    AMENITY = "amenity"
+    SHOP = "shop"
+    TOURISM = "tourism"
+    HISTORIC = "historic"
+    LEISURE = "leisure"
+    NATURAL = "natural"
+    LANDUSE = "landuse"
+    WATERWAY = "waterway"
+    HIGHWAY = "highway"
+    RAILWAY = "railway"
+    AEROWAY = "aeroway"
+    BOUNDARY = "boundary"
+    PLACE = "place"
+    OFFICE = "office"
+    EMERGENCY = "emergency"
+    MILITARY = "military"
+    CRAFT = "craft"
+    MAN_MADE = "man_made"
+    ESTABLISHMENT = "establishment"
+    POINT_OF_INTEREST = "point_of_interest"
+    PARK = "park"
+    OTHER = "other"
+
+
+class ReverseGeocodeLocation(BaseModel):
+    """Single reverse geocoding result location."""
+
+    # Primary address information
+    formatted_address: str = Field(description="Full formatted address string")
+    display_name: str | None = Field(
+        default=None, description="Display name (OSM style)"
+    )
+
+    # Structured address components
+    components: list[AddressComponent] = Field(
+        default_factory=list, description="Structured address components"
+    )
+
+    # Administrative hierarchy
+    country: str | None = Field(default=None, description="Country name")
+    country_code: str | None = Field(
+        default=None, description="ISO 3166-1 alpha-2 country code"
+    )
+    state: str | None = Field(default=None, description="State or province")
+    state_code: str | None = Field(default=None, description="State code")
+    county: str | None = Field(default=None, description="County or district")
+    city: str | None = Field(default=None, description="City or town")
+    suburb: str | None = Field(default=None, description="Suburb or neighborhood")
+    postcode: str | None = Field(default=None, description="Postal code")
+
+    # Street-level details
+    road: str | None = Field(default=None, description="Road or street name")
+    house_number: str | None = Field(default=None, description="House number")
+    house_name: str | None = Field(default=None, description="House or building name")
+
+    # Place information
+    place_type: PlaceType | None = Field(default=None, description="Type of place")
+    place_rank: int | None = Field(
+        default=None, ge=0, le=30, description="OSM place rank (0-30)"
+    )
+    importance: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Importance score"
+    )
+
+    # Geographic details
+    lat: float = Field(ge=-90, le=90, description="Latitude of result")
+    lon: float = Field(ge=-180, le=180, description="Longitude of result")
+    bounding_box: BoundingBox | None = Field(
+        default=None, description="Bounding box of the place"
+    )
+
+    # External identifiers
+    place_id: str | None = Field(default=None, description="Provider-specific place ID")
+    osm_id: str | None = Field(default=None, description="OpenStreetMap ID")
+    osm_type: str | None = Field(
+        default=None, description="OpenStreetMap type (node/way/relation)"
+    )
+    wikidata_id: str | None = Field(default=None, description="Wikidata ID")
+    wikipedia_url: str | None = Field(default=None, description="Wikipedia URL")
+
+    # Additional metadata
+    licence: str | None = Field(default=None, description="Data licence")
+    attribution: str | None = Field(default=None, description="Data attribution")
+
+    # Quality indicators
+    distance_m: float | None = Field(
+        default=None, description="Distance from query point in meters"
+    )
+    confidence: float | None = Field(
+        default=None, ge=0.0, le=1.0, description="Overall confidence score"
+    )
+
+
+class ReverseGeocodeProvider(BaseModel):
+    """Information about the reverse geocoding provider."""
+
+    name: str = Field(description="Name of the provider")
+    endpoint: str | None = Field(default=None, description="API endpoint URL")
+    api_version: str | None = Field(default=None, description="API version")
+    rate_limit: int | None = Field(
+        default=None, description="Rate limit (requests per second)"
+    )
+
+
+class ReverseGeocodeResult(BaseModel):
+    """Complete reverse geocoding result with metadata."""
+
+    # Query information
+    query_lat: float = Field(description="Query latitude")
+    query_lon: float = Field(description="Query longitude")
+
+    # Results
+    locations: list[ReverseGeocodeLocation] = Field(
+        description="List of geocoded locations, ordered by relevance"
+    )
+
+    # Provider information
+    provider: ReverseGeocodeProvider = Field(description="Provider information")
+
+    # Response metadata
+    status: str = Field(description="Response status")
+    error_message: str | None = Field(
+        default=None, description="Error message if status is not OK"
+    )
+    response_time_ms: float | None = Field(
+        default=None, description="Response time in milliseconds"
+    )
+    cache_hit: bool = Field(default=False, description="Whether result was from cache")
+
+    # Timestamps
+    timestamp: datetime = Field(
+        default_factory=datetime.utcnow, description="Timestamp of the request"
+    )
+
+    # Raw response (for debugging)
+    raw_response: dict[str, Any] | None = Field(
+        default=None, description="Raw API response for debugging"
+    )
+
+    def get_best_match(self) -> ReverseGeocodeLocation | None:
+        """Get the best matching location (first in list)."""
+        return self.locations[0] if self.locations else None
+
+    def get_country(self) -> str | None:
+        """Get country from the best match."""
+        best = self.get_best_match()
+        return best.country if best else None
+
+    def get_formatted_address(self) -> str | None:
+        """Get formatted address from the best match."""
+        best = self.get_best_match()
+        return best.formatted_address if best else None
+
+    def filter_by_type(self, place_type: PlaceType) -> list[ReverseGeocodeLocation]:
+        """Filter locations by place type."""
+        return [loc for loc in self.locations if loc.place_type == place_type]
+
+    def to_simple_dict(self) -> dict[str, Any]:
+        """Convert to simple dictionary for easy viewing."""
+        best = self.get_best_match()
+        if not best:
+            return {
+                "status": self.status,
+                "error": self.error_message,
+                "provider": self.provider.name,
+            }
+
+        return {
+            "formatted_address": best.formatted_address,
+            "country": best.country,
+            "state": best.state,
+            "city": best.city,
+            "postcode": best.postcode,
+            "coordinates": {"lat": best.lat, "lon": best.lon},
+            "provider": self.provider.name,
+            "confidence": best.confidence,
+            "status": self.status,
+        }
+
+
+class ReverseGeocodeFetchResult(BaseModel):
+    """Internal result from provider fetch operation."""
+
+    ok: bool = Field(description="Whether the fetch was successful")
+    result: ReverseGeocodeResult | None = Field(
+        default=None, description="Reverse geocoding result"
+    )
+    error: str | None = Field(default=None, description="Error message if not ok")
+    raw: dict[str, Any] = Field(
+        default_factory=dict, description="Raw provider response"
+    )

--- a/geocoding_demo_results.json
+++ b/geocoding_demo_results.json
@@ -1,0 +1,144 @@
+[
+  {
+    "name": "Googleplex, Mountain View",
+    "lat": 37.4224,
+    "lon": -122.0856,
+    "google_elevation": {
+      "elevation_m": 6.513143539428711,
+      "resolution_m": 4.771975994110107,
+      "status": "success"
+    },
+    "google_geocoding": {
+      "address": "Google Building 41, 1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
+      "country": "United States",
+      "state": "California",
+      "city": "Mountain View",
+      "status": "success"
+    },
+    "osm_elevation": {
+      "elevation_m": 8.0,
+      "resolution_m": 90.0,
+      "status": "success"
+    },
+    "osm_geocoding": {
+      "address": "Google Building 41, 1600, Amphitheatre Parkway, Mountain View, Santa Clara County, California, 94043, United States",
+      "country": "United States",
+      "state": "California",
+      "city": "Mountain View",
+      "status": "success"
+    }
+  },
+  {
+    "name": "Mount Everest Base Camp",
+    "lat": 28.0026,
+    "lon": 86.8528,
+    "google_elevation": {
+      "elevation_m": 5299.763671875,
+      "resolution_m": 38.17580795288086,
+      "status": "success"
+    },
+    "google_geocoding": {
+      "address": "2V33+24J Everest Base Camp Helipad, Everest Base Camp Trail, Khumjung 56000, Nepal",
+      "country": "Nepal",
+      "state": "Koshi Province",
+      "city": "Khumjung",
+      "status": "success"
+    },
+    "osm_elevation": {
+      "elevation_m": 5303.0,
+      "resolution_m": 90.0,
+      "status": "success"
+    },
+    "osm_geocoding": {
+      "status": "failed",
+      "error": "No locations found"
+    }
+  },
+  {
+    "name": "Death Valley",
+    "lat": 36.5323,
+    "lon": -116.9325,
+    "google_elevation": {
+      "elevation_m": -80.63458251953125,
+      "resolution_m": 9.543951988220215,
+      "status": "success"
+    },
+    "google_geocoding": {
+      "address": "G3J9+W2 Furnace Creek, CA, USA",
+      "country": "United States",
+      "state": "California",
+      "city": "Furnace Creek",
+      "status": "success"
+    },
+    "osm_elevation": {
+      "elevation_m": -80.0,
+      "resolution_m": 90.0,
+      "status": "success"
+    },
+    "osm_geocoding": {
+      "address": "Inyo County, California, United States",
+      "country": "United States",
+      "state": "California",
+      "city": null,
+      "status": "success"
+    }
+  },
+  {
+    "name": "Tokyo Tower",
+    "lat": 35.6586,
+    "lon": 139.7454,
+    "google_elevation": {
+      "elevation_m": 23.4789981842041,
+      "resolution_m": 9.543951988220215,
+      "status": "success"
+    },
+    "google_geocoding": {
+      "address": "4-ch\u014dme-2-8 Shibak\u014den, Minato City, Tokyo 105-0011, Japan",
+      "country": "Japan",
+      "state": "Tokyo",
+      "city": "Minato City",
+      "status": "success"
+    },
+    "osm_elevation": {
+      "elevation_m": 43.0,
+      "resolution_m": 90.0,
+      "status": "success"
+    },
+    "osm_geocoding": {
+      "address": "Tokyo Tower, Tokyo Tower Street, Shibak\u014den 4, Parc de Shiba, Minato, Tokyo, 106-0041, Japan",
+      "country": "Japan",
+      "state": null,
+      "city": "Minato",
+      "status": "success"
+    }
+  },
+  {
+    "name": "Pacific Ocean",
+    "lat": 30.0,
+    "lon": -140.0,
+    "google_elevation": {
+      "elevation_m": -4651.8173828125,
+      "resolution_m": 610.8129272460938,
+      "status": "success"
+    },
+    "google_geocoding": {
+      "address": "84222222+22",
+      "country": null,
+      "state": null,
+      "city": null,
+      "status": "success"
+    },
+    "osm_elevation": {
+      "elevation_m": 0.0,
+      "resolution_m": 90.0,
+      "status": "success"
+    },
+    "osm_geocoding": {
+      "address": "",
+      "country": null,
+      "state": null,
+      "city": null,
+      "status": "success"
+    }
+  }
+]

--- a/tests/test_google_apis.py
+++ b/tests/test_google_apis.py
@@ -1,0 +1,165 @@
+"""Integration tests for Google APIs (Elevation and Geocoding)."""
+
+import os
+
+import pytest
+
+from biosample_enricher.elevation.providers.google import GoogleElevationProvider
+from biosample_enricher.reverse_geocoding.providers.google import (
+    GoogleReverseGeocodingProvider,
+)
+
+
+@pytest.mark.integration
+class TestGoogleAPIsIntegration:
+    """Integration tests for Google APIs that require actual API calls."""
+
+    @pytest.fixture
+    def api_key(self):
+        """Get API key from environment."""
+        key = os.getenv("GOOGLE_MAIN_API_KEY")
+        if not key:
+            pytest.skip("GOOGLE_MAIN_API_KEY not set")
+        return key
+
+    def test_google_elevation_api(self, api_key):
+        """Test Google Elevation API with real API call."""
+        provider = GoogleElevationProvider(api_key=api_key)
+
+        # Test with known location (Mount Everest base camp)
+        lat, lon = 28.0026, 86.8528
+        result = provider.fetch(lat, lon, read_from_cache=False, write_to_cache=False)
+
+        assert result.ok is True
+        assert result.elevation is not None
+        assert 5000 < result.elevation < 6000  # Expected range for base camp
+        assert result.location is not None
+        assert result.vertical_datum == "EGM96"
+
+        print("\nGoogle Elevation API Test:")
+        print(f"  Location: {lat:.4f}, {lon:.4f}")
+        print(f"  Elevation: {result.elevation:.2f}m")
+        print(f"  Resolution: {result.resolution_m}m")
+        print(f"  Vertical Datum: {result.vertical_datum}")
+
+    def test_google_reverse_geocoding_api(self, api_key):
+        """Test Google Reverse Geocoding API with real API call."""
+        provider = GoogleReverseGeocodingProvider(api_key=api_key)
+
+        # Test with known location (Googleplex)
+        lat, lon = 37.4224, -122.0856
+        result = provider.fetch(
+            lat, lon, read_from_cache=False, write_to_cache=False, limit=5
+        )
+
+        assert result.ok is True
+        assert result.result is not None
+        assert len(result.result.locations) > 0
+
+        best_match = result.result.get_best_match()
+        assert best_match is not None
+        assert best_match.country == "United States"
+        assert best_match.state == "California"
+        assert (
+            "Mountain View" in best_match.formatted_address
+            or best_match.city == "Mountain View"
+        )
+
+        print("\nGoogle Reverse Geocoding API Test:")
+        print(f"  Location: {lat:.4f}, {lon:.4f}")
+        print(f"  Formatted Address: {best_match.formatted_address}")
+        print(f"  Country: {best_match.country} ({best_match.country_code})")
+        print(f"  State: {best_match.state}")
+        print(f"  City: {best_match.city}")
+        print(f"  Postcode: {best_match.postcode}")
+        print(f"  Place ID: {best_match.place_id}")
+        print(f"  Total Results: {len(result.result.locations)}")
+
+    def test_google_apis_combined(self, api_key):
+        """Test both Google APIs together for the same location."""
+        elevation_provider = GoogleElevationProvider(api_key=api_key)
+        geocoding_provider = GoogleReverseGeocodingProvider(api_key=api_key)
+
+        # Test with a mountainous location (Yosemite Valley)
+        lat, lon = 37.7456, -119.5936
+
+        # Run both API calls
+        elevation_result = elevation_provider.fetch(
+            lat, lon, read_from_cache=False, write_to_cache=False
+        )
+        geocoding_result = geocoding_provider.fetch(
+            lat, lon, read_from_cache=False, write_to_cache=False, limit=3
+        )
+
+        # Verify elevation result
+        assert elevation_result.ok is True
+        assert elevation_result.elevation is not None
+        assert (
+            1000 < elevation_result.elevation < 2500
+        )  # Expected range for Yosemite Valley
+
+        # Verify geocoding result
+        assert geocoding_result.ok is True
+        assert geocoding_result.result is not None
+        best_match = geocoding_result.result.get_best_match()
+        assert best_match is not None
+        assert best_match.country == "United States"
+        assert best_match.state == "California"
+
+        print("\nCombined Google APIs Test (Yosemite Valley):")
+        print(f"  Location: {lat:.4f}, {lon:.4f}")
+        print(f"  Elevation: {elevation_result.elevation:.2f}m")
+        print(f"  Address: {best_match.formatted_address}")
+        print("  Place Components:")
+        print(f"    - Country: {best_match.country}")
+        print(f"    - State: {best_match.state}")
+        print(f"    - County: {best_match.county}")
+        print(f"    - City: {best_match.city}")
+
+    def test_google_apis_ocean_location(self, api_key):
+        """Test Google APIs with an ocean location."""
+        elevation_provider = GoogleElevationProvider(api_key=api_key)
+        geocoding_provider = GoogleReverseGeocodingProvider(api_key=api_key)
+
+        # Test with Pacific Ocean location
+        lat, lon = 30.0, -140.0
+
+        # Test elevation (should be negative for ocean)
+        elevation_result = elevation_provider.fetch(
+            lat, lon, read_from_cache=False, write_to_cache=False
+        )
+
+        assert elevation_result.ok is True
+        assert elevation_result.elevation is not None
+        assert elevation_result.elevation < 0  # Below sea level
+
+        # Test reverse geocoding (might return no results or ocean name)
+        geocoding_result = geocoding_provider.fetch(
+            lat, lon, read_from_cache=False, write_to_cache=False
+        )
+
+        assert geocoding_result.ok is True
+        assert geocoding_result.result is not None
+        # Ocean locations might have zero results
+
+        print("\nOcean Location Test (Pacific Ocean):")
+        print(f"  Location: {lat:.4f}, {lon:.4f}")
+        print(f"  Elevation: {elevation_result.elevation:.2f}m (below sea level)")
+        print(f"  Geocoding Results: {len(geocoding_result.result.locations)}")
+        if geocoding_result.result.locations:
+            best_match = geocoding_result.result.get_best_match()
+            print(f"  Nearest: {best_match.formatted_address}")
+
+    def test_google_apis_error_handling(self, api_key):
+        """Test error handling for invalid coordinates."""
+        elevation_provider = GoogleElevationProvider(api_key=api_key)
+        geocoding_provider = GoogleReverseGeocodingProvider(api_key=api_key)
+
+        # Test with invalid coordinates
+        with pytest.raises(ValueError, match="Invalid latitude"):
+            elevation_provider.fetch(91, 0)
+
+        with pytest.raises(ValueError, match="Invalid longitude"):
+            geocoding_provider.fetch(0, 181)
+
+        print("\nError handling tests passed successfully")

--- a/tests/test_reverse_geocoding.py
+++ b/tests/test_reverse_geocoding.py
@@ -1,0 +1,244 @@
+"""Tests for reverse geocoding providers and service."""
+
+import os
+import time
+
+import pytest
+
+from biosample_enricher.reverse_geocoding import (
+    GoogleReverseGeocodingProvider,
+    OSMReverseGeocodingProvider,
+    ReverseGeocodingService,
+)
+from biosample_enricher.reverse_geocoding_models import (
+    AddressComponentType,
+)
+
+
+class TestOSMReverseGeocodingProvider:
+    """Tests for OSM Nominatim reverse geocoding provider."""
+
+    @pytest.fixture
+    def provider(self):
+        """Create OSM provider instance."""
+        return OSMReverseGeocodingProvider()
+
+    @pytest.mark.integration
+    def test_fetch_success(self, provider):
+        """Test successful reverse geocoding fetch with real API."""
+        # Perform fetch with real API call to Googleplex location
+        result = provider.fetch(37.4224, -122.0856)
+
+        # Verify result
+        assert result.ok is True
+        assert result.result is not None
+        assert len(result.result.locations) >= 1
+
+        location = result.result.locations[0]
+        assert location.formatted_address is not None
+        assert (
+            "Mountain View" in location.formatted_address
+            or location.city == "Mountain View"
+        )
+        assert location.country == "United States"
+        assert location.country_code == "US"
+        assert location.state == "California"
+        # Don't check exact values as they can change
+        assert location.postcode is not None
+        assert location.road is not None
+
+    @pytest.mark.integration
+    def test_fetch_with_multiple_results(self, provider):
+        """Test fetching multiple results with real API."""
+        # Test with a well-known location
+        result = provider.fetch(37.4224, -122.0856, limit=3)
+
+        assert result.ok is True
+        assert result.result is not None
+        # Should get at least one result
+        assert len(result.result.locations) >= 1
+        # All results should be near the requested location
+        for location in result.result.locations:
+            assert location.formatted_address is not None
+
+    def test_fetch_invalid_coordinates(self, provider):
+        """Test handling of invalid coordinates."""
+        # Test with invalid latitude
+        with pytest.raises(ValueError, match="Invalid latitude"):
+            provider.fetch(91.0, 0.0)
+
+        # Test with invalid longitude
+        with pytest.raises(ValueError, match="Invalid longitude"):
+            provider.fetch(0.0, 181.0)
+
+    @pytest.mark.integration
+    def test_rate_limiting(self, provider):
+        """Test rate limiting for public Nominatim."""
+        # First request
+        start_time = time.time()
+        result1 = provider.fetch(0, 0, read_from_cache=False)
+
+        # Second request should be rate limited (1 second minimum)
+        result2 = provider.fetch(1, 1, read_from_cache=False)
+        elapsed = time.time() - start_time
+
+        # Should take at least 1 second due to rate limiting
+        assert elapsed >= 1.0
+        # Both results should be valid (ocean locations)
+        assert result1.ok is True
+        assert result2.ok is True
+
+
+class TestGoogleReverseGeocodingProvider:
+    """Tests for Google Geocoding reverse geocoding provider."""
+
+    @pytest.fixture
+    def provider(self):
+        """Create Google provider instance."""
+        # Skip if no API key
+        if not os.getenv("GOOGLE_MAIN_API_KEY"):
+            pytest.skip("Google API key not available")
+        return GoogleReverseGeocodingProvider()
+
+    @pytest.mark.integration
+    def test_fetch_success(self, provider):
+        """Test successful reverse geocoding fetch with real API."""
+        # Perform fetch with real API call to Googleplex location
+        result = provider.fetch(37.4224, -122.0856)
+
+        # Verify result
+        assert result.ok is True
+        assert result.result is not None
+        assert len(result.result.locations) >= 1
+
+        location = result.result.locations[0]
+        assert location.formatted_address is not None
+        assert location.country == "United States"
+        assert location.country_code == "US"
+        assert location.state == "California"
+        assert location.state_code == "CA"
+        assert (
+            "Mountain View" in location.formatted_address
+            or location.city == "Mountain View"
+        )
+        # Don't check exact values as they can change
+        assert location.place_id is not None
+
+    @pytest.mark.integration
+    def test_fetch_ocean_location(self, provider):
+        """Test fetching ocean location (may return zero results)."""
+        # Test with middle of Pacific Ocean
+        result = provider.fetch(0, -140)
+
+        assert result.ok is True
+        assert result.result is not None
+        # Ocean locations may have zero results or generic ocean results
+        if len(result.result.locations) == 0:
+            assert result.result.status == "ZERO_RESULTS"
+
+    def test_invalid_coordinates(self, provider):
+        """Test validation of invalid coordinates."""
+        # Test with invalid latitude
+        with pytest.raises(ValueError, match="Invalid latitude"):
+            provider.fetch(91.0, 0.0)
+
+        # Test with invalid longitude
+        with pytest.raises(ValueError, match="Invalid longitude"):
+            provider.fetch(0.0, 181.0)
+
+    @pytest.mark.integration
+    def test_parse_address_components(self, provider):
+        """Test parsing of address components with real API."""
+        result = provider.fetch(37.4224, -122.0856)
+
+        assert result.ok is True
+        assert result.result is not None
+        assert len(result.result.locations) >= 1
+
+        location = result.result.locations[0]
+        components = location.components
+
+        # Check that we have some components
+        assert len(components) > 0
+        component_types = {c.type for c in components}
+        # At minimum we should have country
+        assert AddressComponentType.COUNTRY in component_types
+
+
+class TestReverseGeocodingService:
+    """Tests for reverse geocoding service."""
+
+    @pytest.fixture
+    def service(self):
+        """Create service instance."""
+        return ReverseGeocodingService()
+
+    @pytest.mark.integration
+    def test_reverse_geocode_with_specific_provider(self, service):
+        """Test reverse geocoding with specific provider."""
+        # Use OSM provider which is always available
+        result = service.reverse_geocode(37.4224, -122.0856, provider="osm")
+
+        assert result is not None
+        assert result.get_formatted_address() is not None
+        assert len(result.locations) >= 1
+
+    @pytest.mark.integration
+    def test_reverse_geocode_auto_selection(self, service):
+        """Test auto-selection of provider."""
+        result = service.reverse_geocode(37.4224, -122.0856)
+
+        assert result is not None
+        assert result.get_formatted_address() is not None
+        # Should use Google if available, otherwise OSM
+        assert result.provider.name in ["google_geocoding", "osm_nominatim"]
+
+    @pytest.mark.integration
+    def test_reverse_geocode_multiple(self, service):
+        """Test reverse geocoding with multiple providers."""
+        results = service.reverse_geocode_multiple(37.4224, -122.0856)
+
+        assert "osm" in results
+        assert results["osm"].get_formatted_address() is not None
+
+        if "google" in service.providers:
+            assert "google" in results
+            assert results["google"].get_formatted_address() is not None
+
+    @pytest.mark.integration
+    def test_compare_providers(self, service):
+        """Test provider comparison functionality."""
+        comparison = service.compare_providers(37.4224, -122.0856)
+
+        assert "query" in comparison
+        assert comparison["query"]["lat"] == 37.4224
+        assert comparison["query"]["lon"] == -122.0856
+
+        assert "providers" in comparison
+        assert "osm" in comparison["providers"]
+
+        # If both providers return US results, check consensus
+        if (
+            "osm" in comparison["providers"]
+            and comparison["providers"]["osm"].get("country") == "United States"
+            and "google" in comparison["providers"]
+            and comparison["providers"]["google"].get("country") == "United States"
+        ):
+            assert "consensus" in comparison
+            if "country" in comparison["consensus"]:
+                assert comparison["consensus"]["country"]["value"] == "United States"
+
+    def test_get_available_providers(self, service):
+        """Test getting list of available providers."""
+        providers = service.get_available_providers()
+        assert "osm" in providers
+        # Google may or may not be available depending on API key
+
+    def test_get_provider(self, service):
+        """Test getting specific provider."""
+        osm_provider = service.get_provider("osm")
+        assert osm_provider is not None
+        assert osm_provider.name == "osm_nominatim"
+
+        invalid_provider = service.get_provider("invalid")
+        assert invalid_provider is None


### PR DESCRIPTION
- Implement reverse geocoding providers for OSM Nominatim and Google Geocoding APIs
- Create thorough Pydantic models for structured address data with 30+ component types
- Add rate limiting for OSM Nominatim (1 req/sec for public API)
- Create service layer for coordinating multiple providers
- Remove all async/futures/concurrency - purely synchronous implementation
- Add comprehensive tests without mocks - all use real API calls
- Include demo script showcasing both elevation and reverse geocoding
- Ensure full type safety without any type ignore comments
- All 111 tests pass, all CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)