### PR TITLE
Disable uv cache to fix persistent GitHub cache errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v3
       with:
-        enable-cache: true
+        enable-cache: false
 
     - name: Set up Python ${{ matrix.python-version }}
       run: uv python install ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
- Disables the uv cache in GitHub Actions CI workflow
- This avoids the persistent cache service 400 errors we've been seeing

## Context
GitHub's cache service has been returning 400 errors consistently for several days, causing warnings in all CI runs. While these don't affect test results, they add noise to the CI output.

## Solution
Set `enable-cache: false` in the uv setup action to bypass the cache entirely until GitHub's service stabilizes.

Fixes #76