### PR TITLE
Fix import-time dependency detection

### DIFF
--- a/biosample_enricher/http_cache.py
+++ b/biosample_enricher/http_cache.py
@@ -6,15 +6,8 @@ import os
 from typing import Any
 
 import requests
+from pymongo import MongoClient
 from requests_cache import CachedSession, create_key
-
-try:
-    from pymongo import MongoClient
-
-    HAS_PYMONGO = True
-except ImportError:
-    MongoClient = None  # type: ignore[misc,assignment]
-    HAS_PYMONGO = False
 
 from biosample_enricher.logging_config import get_logger
 
@@ -91,11 +84,8 @@ def _mongo_session(
     uri: str, db_name: str, collection_name: str, timeout_ms: int = 5000
 ) -> CachedSession:
     """Create MongoDB-backed cached session."""
-    if not HAS_PYMONGO:
-        raise ImportError("pymongo not available - cannot use MongoDB backend")
-
     logger.debug(f"Attempting MongoDB connection to {uri}")
-    client: MongoClient = MongoClient(uri, serverSelectionTimeoutMS=timeout_ms)  # type: ignore[misc]
+    client: MongoClient = MongoClient(uri, serverSelectionTimeoutMS=timeout_ms)
     client.admin.command("ping")  # Fail fast if unreachable
     logger.info(f"Using MongoDB cache backend: {db_name}.{collection_name}")
     return CachedSession(

--- a/biosample_enricher/osm_features/service.py
+++ b/biosample_enricher/osm_features/service.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from biosample_enricher.logging_config import get_logger
+from biosample_enricher.osm_features.google_provider import GooglePlacesProvider
 from biosample_enricher.osm_features.models import (
     CombinedFeaturesResult,
     Coordinates,
@@ -11,16 +12,6 @@ from biosample_enricher.osm_features.models import (
 from biosample_enricher.osm_features.provider import OSMOverpassProvider
 
 logger = get_logger(__name__)
-
-# Import Google provider with graceful fallback
-try:
-    from biosample_enricher.osm_features.google_provider import GooglePlacesProvider
-
-    HAS_GOOGLE_PROVIDER = True
-except ImportError as e:
-    logger.warning(f"Google Places provider not available: {e}")
-    GooglePlacesProvider = None  # type: ignore[misc,assignment]
-    HAS_GOOGLE_PROVIDER = False
 
 
 class OSMFeaturesService:
@@ -37,9 +28,9 @@ class OSMFeaturesService:
         self.default_radius_m = default_radius_m
         self.osm_provider = OSMOverpassProvider()
 
-        # Initialize Google provider if available and enabled
+        # Initialize Google provider if enabled
         self.google_provider = None
-        if HAS_GOOGLE_PROVIDER and enable_google:
+        if enable_google:
             try:
                 self.google_provider = GooglePlacesProvider()
                 if not self.google_provider.is_available():


### PR DESCRIPTION
## Summary
Remove try/except around imports to comply with CLAUDE.md guidelines.

## Changes
- **biosample_enricher/http_cache.py**: Import pymongo directly at top of file
- **biosample_enricher/osm_features/service.py**: Import GooglePlacesProvider directly at top of file
- Remove `HAS_PYMONGO` and `HAS_GOOGLE_PROVIDER` constants
- Remove import-time dependency detection patterns

## Behavior
- Runtime behavior unchanged
- MongoDB backend still gracefully falls back to SQLite when connection fails
- Google provider still handles API key unavailability at runtime

## Testing
- All 234 tests pass
- mypy type checking passes
- ruff linting passes

## Note
pymongo is currently a required dependency but will be made optional in #142 (Restructure Dependencies: Core vs Optional Groups).

Resolves #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)