### PR TITLE
Add biosample-enricher-metrics CLI entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ metrics-local: | data/outputs/metrics ## Run metrics evaluation (usage: make met
 	@echo "NMDC database: $(NMDC_DB), GOLD database: $(GOLD_DB)"
 	NMDC_MONGO_CONNECTION="mongodb://ncbi_reader:register_manatee_coach78@localhost:27778/?directConnection=true&authMechanism=DEFAULT&authSource=admin" \
 	GOLD_MONGO_CONNECTION="mongodb://ncbi_reader:register_manatee_coach78@localhost:27778/?directConnection=true&authMechanism=DEFAULT&authSource=admin" \
-	uv run biosample-enricher metrics evaluate \
+	uv run biosample-enricher-metrics evaluate \
 		--nmdc-samples $(NMDC_SAMPLES) \
 		--gold-samples $(GOLD_SAMPLES) \
 		--output-dir data/outputs/metrics \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,8 @@ schema-inference = "biosample_enricher.schema_inference:main"
 schema-statistics = "biosample_enricher.schema_statistics:main"
 # Utility commands
 biosample-version = "biosample_enricher.cli:show_version"
-metrics-dashboard = "biosample_enricher.metrics.dashboard:main"
-metrics-markdown = "biosample_enricher.metrics.markdown:main"
+# Metrics evaluation (requires optional dependencies: pip install biosample-enricher[metrics])
+biosample-enricher-metrics = "biosample_enricher.cli_metrics:metrics"
 elevation-mapper-demo = "biosample_enricher.biosample_elevation_mapper:demonstrate_field_mapping"
 # Note: Demo scripts moved to examples/ directory and excluded from package.
 # Run demos using: make demo-weather, make demo-geocoding, etc.


### PR DESCRIPTION
## Problem
After removing metrics from the main CLI (PR #179) to avoid forcing matplotlib/seaborn imports, we broke the development workflow:
- `make metrics-local` no longer works
- No way to run metrics evaluation commands

## Solution
Add a dedicated `biosample-enricher-metrics` CLI entry point that developers can use without polluting the main CLI for end users.

**Changes**:
1. **New CLI entry point**: `biosample-enricher-metrics` → `cli_metrics.py:metrics`
2. **Update Makefile**: Change `biosample-enricher metrics` to `biosample-enricher-metrics`
3. **Remove broken entry points**: `metrics-dashboard` and `metrics-markdown` (pointed to non-existent functions)

## Testing
```bash
# Metrics CLI works
$ uv run biosample-enricher-metrics --help
Usage: biosample-enricher-metrics [OPTIONS] COMMAND [ARGS]...
  Evaluate enrichment coverage metrics.
Commands:
  evaluate         Evaluate enrichment coverage metrics
  test-connection  Test database connections
  visualize        Create visualizations from CSV

# Main CLI still clean (no viz imports)
$ uv run python -c "from biosample_enricher.cli import main; import sys; print([m for m in sys.modules if 'matplotlib' in m or 'seaborn' in m])"
[]

# Makefile works
$ make metrics-local NMDC_SAMPLES=2 GOLD_SAMPLES=2
# (runs successfully)
```

## Impact
- ✅ Development workflow restored
- ✅ Main CLI remains clean (no optional dependency imports)
- ✅ All 234 tests pass
- ✅ PyPI users unaffected (metrics requires `pip install biosample-enricher[metrics]`)

## For Users
**Development**: Use `biosample-enricher-metrics` or `make metrics-local`
**Production**: Install with `pip install biosample-enricher[metrics]` first