### PR TITLE
Populate all documentation stub pages and focus on get_submission_values()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,8 @@ logs/*
 
 # Auto-generated version file by hatch-vcs
 biosample_enricher/_version.py
+
+# MCP server cache files (local development)
+.mcp.json
+.channels_cache_v2.json
+.users_cache.json

--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -1,4 +1,115 @@
 Models
 ======
 
-Coming soon.
+Data models used throughout the biosample-enricher package.
+
+Core Models
+-----------
+
+These models are shared across multiple services and represent fundamental concepts.
+
+biosample_enricher.models
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Service-Specific Models
+------------------------
+
+Each service has its own specialized models for requests and responses.
+
+Weather Models
+~~~~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.weather.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Marine Models
+~~~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.marine.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Soil Models
+~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.soil.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Land Cover Models
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.land.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Geocoding Models
+~~~~~~~~~~~~~~~~
+
+Forward Geocoding:
+
+.. automodule:: biosample_enricher.forward_geocoding.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Reverse Geocoding:
+
+.. automodule:: biosample_enricher.reverse_geocoding_models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+OSM Features Models
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: biosample_enricher.osm_features.models
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Common Patterns
+---------------
+
+All models follow these conventions:
+
+Type Safety
+~~~~~~~~~~~
+
+- Full type hints using Python 3.11+ syntax
+- Pydantic validation for all external data
+- mypy strict mode compliance
+
+Coordinate Handling
+~~~~~~~~~~~~~~~~~~~
+
+- Latitude: -90 to 90 decimal degrees
+- Longitude: -180 to 180 decimal degrees
+- Automatic canonicalization to 4 decimal places (~11m precision)
+
+Observation Pattern
+~~~~~~~~~~~~~~~~~~~
+
+Many services return ``Observation`` objects with:
+
+- ``value_numeric``: Numeric measurement (if applicable)
+- ``value_string``: String value (if applicable)
+- ``provider``: Data source information
+- ``metadata``: Additional context
+
+See Also
+--------
+
+- :doc:`services` - Service implementations using these models
+- :doc:`providers` - Provider-specific response handling
+- :doc:`../architecture` - Overall system design

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -1,4 +1,116 @@
 Architecture
 ============
 
-Coming soon.
+Core Design
+-----------
+
+The biosample-enricher architecture focuses on one primary use case: **retrieving NMDC submission-schema values from geographic coordinates**.
+
+Key Components
+--------------
+
+get_submission_values()
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The main entry point that orchestrates all data retrieval:
+
+.. code-block:: python
+
+   from biosample_enricher.submission_values import get_submission_values
+
+   result = get_submission_values(
+       lat=37.7749,
+       lon=-122.4194,
+       slots=["annual_precpt", "annual_temp"]
+   )
+
+**See** :doc:`submission_values` for complete documentation.
+
+Multi-Provider System
+~~~~~~~~~~~~~~~~~~~~~
+
+Each data type (climate, elevation, etc.) has multiple providers:
+
+- **Climate normals**: meteostat, nasa_power
+- **Elevation**: USGS, Google, Open Topo Data, OSM
+- **Weather**: meteostat, open-meteo
+- **Marine**: GEBCO, ESA CCI, NOAA
+
+The system automatically:
+
+1. Queries multiple providers in parallel
+2. Validates and normalizes responses
+3. Computes consensus values (median or mean)
+4. Returns metadata about which providers were used
+
+**See** :doc:`api/providers` for provider comparison.
+
+HTTP Caching
+~~~~~~~~~~~~
+
+All external API calls go through a centralized caching layer using ``requests-cache``:
+
+- **MongoDB primary backend** (with SQLite fallback)
+- **Coordinate canonicalization** (4 decimal places)
+- **Configurable cache control** via ``read_from_cache``/``write_to_cache`` parameters
+- **Automatic TTL management**
+
+Located in: ``biosample_enricher/http_cache.py``
+
+Data Flow
+---------
+
+1. **User calls** ``get_submission_values(lat, lon, slots)``
+2. **Dispatcher** routes each slot to appropriate service (climate, elevation, etc.)
+3. **Service** queries multiple providers via cached HTTP client
+4. **Providers** return data in standardized format
+5. **Aggregator** computes consensus values
+6. **Result** returns values + metadata
+
+Example result structure:
+
+.. code-block:: python
+
+   {
+       "values": {
+           "annual_precpt": 519.3,
+           "annual_temp": 14.1
+       },
+       "metadata": {
+           "climate_normals": {
+               "providers_used": ["meteostat", "nasa_power"],
+               "provider_results": {
+                   "meteostat": {"annual_precpt": 520.1, "annual_temp": 14.0},
+                   "nasa_power": {"annual_precpt": 518.5, "annual_temp": 14.2}
+               }
+           }
+       }
+   }
+
+Design Principles
+-----------------
+
+1. **One way to do it**: ``get_submission_values()`` is THE function
+2. **Fail gracefully**: Missing providers don't break the system
+3. **Cache aggressively**: Minimize API calls
+4. **Type safety**: Full type annotations with mypy strict mode
+5. **Test thoroughly**: Unit, integration, and network test categories
+
+Future Development
+------------------
+
+Archived code (in ``archived/`` directory) includes:
+
+- MongoDB biosample adapters
+- Service-specific CLIs
+- Metrics evaluation framework
+- Demo scripts
+
+These may be restored when needed. See ``archived/README.md`` for restoration instructions.
+
+Related Documentation
+---------------------
+
+- :doc:`submission_values` - Main API documentation
+- :doc:`api/providers` - Provider comparison and details
+- :doc:`testing` - Testing standards and guidelines

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,4 +1,20 @@
 Changelog
 =========
 
-Coming soon.
+For the complete changelog and release history, see the `GitHub Releases page <https://github.com/contextualizer-ai/biosample-enricher/releases>`_.
+
+Recent Releases
+---------------
+
+The project uses semantic versioning with automated releases from CI/CD.
+
+Latest Release
+~~~~~~~~~~~~~~
+
+See the `latest release <https://github.com/contextualizer-ai/biosample-enricher/releases/latest>`_ for the most recent version.
+
+All Releases
+~~~~~~~~~~~~
+
+Browse all releases and their changelogs at:
+https://github.com/contextualizer-ai/biosample-enricher/releases

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,4 +1,116 @@
 CLI Reference
 =============
 
-Coming soon.
+The main CLI for getting NMDC submission values.
+
+biosample-enricher
+------------------
+
+Main command-line interface for retrieving NMDC submission-schema values.
+
+.. code-block:: bash
+
+   # Installation includes CLI
+   uv pip install biosample-enricher
+
+   # Get help
+   biosample-enricher --help
+
+Usage
+~~~~~
+
+**Get climate data:**
+
+.. code-block:: bash
+
+   biosample-enricher \
+       --lat 37.7749 \
+       --lon -122.4194 \
+       --slots annual_precpt annual_temp
+
+**Get multiple slot types:**
+
+.. code-block:: bash
+
+   biosample-enricher \
+       --lat 40.7128 \
+       --lon -74.0060 \
+       --slots annual_precpt annual_temp elev
+
+**Output to file:**
+
+.. code-block:: bash
+
+   biosample-enricher \
+       --lat 42.3601 \
+       --lon -71.0589 \
+       --slots annual_precpt annual_temp \
+       --output values.json
+
+Options
+~~~~~~~
+
+.. code-block:: text
+
+   --lat FLOAT              Latitude in decimal degrees (required)
+   --lon FLOAT              Longitude in decimal degrees (required)
+   --slots TEXT [TEXT ...]  Submission-schema slot names (required)
+   --output PATH            Output file path (default: stdout)
+   --providers TEXT [...]   Specific providers to use (optional)
+   --help                   Show help message
+
+Available Slots
+~~~~~~~~~~~~~~~
+
+See :doc:`submission_values` for the complete list of supported slots.
+
+Quick reference:
+
+- **Climate**: annual_precpt, annual_temp
+- **Elevation**: elev
+- **Marine**: depth
+- **Soil**: ph, soil_type
+- **Weather**: temp, humidity, wind_speed, wind_direction, solar_irradiance
+
+Python API Alternative
+----------------------
+
+For programmatic access, use the Python API instead:
+
+.. code-block:: python
+
+   from biosample_enricher.submission_values import get_submission_values
+
+   result = get_submission_values(
+       lat=37.7749,
+       lon=-122.4194,
+       slots=["annual_precpt", "annual_temp"]
+   )
+
+See :doc:`submission_values` for complete Python API documentation.
+
+Troubleshooting
+---------------
+
+**"Unsupported slot" error**
+
+The slot name you provided isn't supported. Check the available slots above or run:
+
+.. code-block:: bash
+
+   biosample-enricher --help
+
+**"Invalid coordinates" error**
+
+Latitude must be -90 to 90, longitude must be -180 to 180.
+
+**No data returned for a slot**
+
+Some slots may not have data available for all locations. This is normal - the slot will be omitted from results.
+
+Related Documentation
+---------------------
+
+- :doc:`submission_values` - Full Python API documentation
+- :doc:`quickstart` - Quick start guide
+- `Examples <https://github.com/contextualizer-ai/biosample-enricher/tree/main/examples>`_ - Sample code

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,4 +1,5 @@
 Contributing
 ============
 
-Coming soon.
+.. include:: ../../CONTRIBUTING.md
+   :parser: myst_parser.sphinx_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,59 +18,51 @@ Infer AI-friendly environmental and geographic metadata about biosamples from mu
 Overview
 --------
 
-Biosample Enricher provides 8 specialized services for enriching biosample metadata with environmental and geographic information from authoritative data sources. Each service focuses on a specific domain and returns structured, type-safe data ready for analysis or AI applications.
+Get NMDC submission-schema values from geographic coordinates. Biosample Enricher retrieves environmental and geographic metadata from authoritative data sources and returns it in the format needed for NMDC submissions.
 
 Features
 --------
 
-- **8 Specialized Services**: Elevation, soil, weather, marine, land cover, forward/reverse geocoding, geographic features
-- **Service-Based Architecture**: Independent services with focused responsibilities
+- **Simple API**: One function - ``get_submission_values(lat, lon, slots)``
+- **Multiple Data Sources**: Climate normals, elevation, weather, soil, marine data
+- **Multi-Provider Consensus**: Queries multiple providers and returns consensus values
 - **Type Safety**: Full type hints with Pydantic validation and mypy checking
 - **Smart Caching**: HTTP caching with coordinate canonicalization for efficiency
-- **Multiple Providers**: Automatic fallback between data providers (USGS, Google, OSM, etc.)
-- **Click-Based CLIs**: User-friendly command-line tools for each service
-- **Flexible Installation**: Core services only, or add optional mongodb/metrics/schema extras
+- **CLI Tool**: Get values without writing code
+- **Flexible Installation**: Core functionality only, or add optional mongodb/metrics/schema extras
 
 Installation
 ------------
 
-Using UV (Recommended)
-^^^^^^^^^^^^^^^^^^^^^^
-
 .. code-block:: bash
 
-   # Basic installation - all 8 enrichment services
-   uv add biosample-enricher
+   # Recommended: Use uv
+   uv pip install biosample-enricher
 
-   # With optional dependencies
-   uv add biosample-enricher --extra metrics   # Metrics and visualization
-   uv add biosample-enricher --extra mongodb   # MongoDB support for NMDC/GOLD
-   uv add biosample-enricher --extra schema    # Schema analysis tools
-   uv add biosample-enricher --extra all       # All optional features
-
-Using Pip
-^^^^^^^^^
-
-.. code-block:: bash
-
+   # Or with pip
    pip install biosample-enricher
-   pip install biosample-enricher[metrics]
+
+   # Optional dependencies
+   uv pip install biosample-enricher[metrics]   # Metrics and visualization
+   uv pip install biosample-enricher[mongodb]   # MongoDB support for NMDC/GOLD
+   uv pip install biosample-enricher[all]       # All optional features
 
 Quick Start
 -----------
 
 .. code-block:: python
 
-   from biosample_enricher import ElevationService, ElevationRequest
+   from biosample_enricher.submission_values import get_submission_values
 
-   # Get elevation for a location
-   service = ElevationService()
-   request = ElevationRequest(latitude=40.7128, longitude=-74.0060)
-   observations = service.get_elevation(request)
+   # Get NMDC submission values for a location
+   result = get_submission_values(
+       lat=37.7749,   # San Francisco
+       lon=-122.4194,
+       slots=["annual_precpt", "annual_temp", "elev"]
+   )
 
-   for obs in observations:
-       if obs.value_numeric is not None:
-           print(f"{obs.provider.name}: {obs.value_numeric}m")
+   print(result["values"])
+   # {'annual_precpt': 519.3, 'annual_temp': 14.1, 'elev': 10.2}
 
 .. toctree::
    :maxdepth: 2
@@ -78,8 +70,9 @@ Quick Start
 
    installation
    quickstart
-   services/index
+   submission_values
    cli
+   services/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/license.rst
+++ b/docs/source/license.rst
@@ -1,4 +1,5 @@
 License
 =======
 
-Coming soon.
+.. include:: ../../LICENSE
+   :literal:

--- a/docs/source/provider_reliability.rst
+++ b/docs/source/provider_reliability.rst
@@ -1,4 +1,22 @@
 Provider Reliability
 ====================
 
-Coming soon.
+Comprehensive analysis of data provider reliability across all service domains.
+
+.. include:: ../PROVIDER_RELIABILITY_ANALYSIS.md
+   :parser: myst_parser.sphinx_
+
+Provider Roadmap
+----------------
+
+See the full roadmap for provider improvements and future development:
+
+.. include:: ../PROVIDER_RELIABILITY_ROADMAP.md
+   :parser: myst_parser.sphinx_
+
+Related Documentation
+---------------------
+
+- :doc:`api/providers` - Detailed provider comparison and technical specifications
+- `Provider Metadata YAML <https://github.com/contextualizer-ai/biosample-enricher/blob/main/config/provider_metadata.yaml>`_ - Structured provider configuration
+- `Flaky Tests <https://github.com/contextualizer-ai/biosample-enricher/blob/main/docs/flaky-tests.md>`_ - Known test reliability issues

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,4 +1,95 @@
 Quick Start
 ===========
 
-Coming soon.
+Get NMDC submission values in 3 steps
+--------------------------------------
+
+**Step 1: Install**
+
+.. code-block:: bash
+
+   uv pip install biosample-enricher
+
+**Step 2: Get values**
+
+.. code-block:: python
+
+   from biosample_enricher.submission_values import get_submission_values
+
+   result = get_submission_values(
+       lat=37.7749,   # San Francisco
+       lon=-122.4194,
+       slots=["annual_precpt", "annual_temp"]
+   )
+
+   print(result["values"])
+   # {'annual_precpt': 519.3, 'annual_temp': 14.1}
+
+**Step 3: Use in your NMDC submission**
+
+The values are already in the correct units and format for NMDC submission-schema.
+
+Next Steps
+----------
+
+- **Full guide**: :doc:`submission_values` - Complete documentation with all supported slots
+- **Examples**: `examples/ directory <https://github.com/contextualizer-ai/biosample-enricher/tree/main/examples>`_ - Copy-paste ready code
+- **Available slots**: See :ref:`what-values-can-you-get` for the complete list
+
+Common Use Cases
+----------------
+
+Get climate data
+~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   result = get_submission_values(
+       lat=42.3601,
+       lon=-71.0589,
+       slots=["annual_precpt", "annual_temp"]
+   )
+
+Get elevation
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   result = get_submission_values(
+       lat=40.7128,
+       lon=-74.0060,
+       slots=["elev"]
+   )
+
+Mix multiple slot types
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   result = get_submission_values(
+       lat=46.7867,
+       lon=-121.7365,
+       slots=["annual_precpt", "annual_temp", "elev"]
+   )
+
+Handle errors
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   try:
+       result = get_submission_values(
+           lat=37.7749,
+           lon=-122.4194,
+           slots=["annual_precpt", "invalid_slot"]
+       )
+   except ValueError as e:
+       print(f"Error: {e}")
+       # Error includes list of supported slots
+
+Need Help?
+----------
+
+- **Questions?** See the :doc:`submission_values` guide
+- **Issues?** `Report on GitHub <https://github.com/contextualizer-ai/biosample-enricher/issues>`_
+- **Examples not working?** Check the `examples/ README <https://github.com/contextualizer-ai/biosample-enricher/blob/main/examples/README.md>`_

--- a/docs/source/services/index.rst
+++ b/docs/source/services/index.rst
@@ -1,4 +1,75 @@
-Services
-========
+Getting NMDC Submission Values
+===============================
 
-Coming soon.
+.. important::
+   **Looking for how to get NMDC submission values?**
+
+   The main function you need is :doc:`../submission_values`.
+
+The biosample-enricher package focuses on one primary use case: **retrieving NMDC submission-schema values from geographic coordinates**.
+
+Quick Example
+-------------
+
+.. code-block:: python
+
+   from biosample_enricher.submission_values import get_submission_values
+
+   result = get_submission_values(
+       lat=37.7749,
+       lon=-122.4194,
+       slots=["annual_precpt", "annual_temp", "elev"]
+   )
+
+   print(result["values"])
+   # {'annual_precpt': 519.3, 'annual_temp': 14.1, 'elev': 10.2}
+
+See the Complete Guide
+-----------------------
+
+:doc:`../submission_values`
+   Complete documentation for ``get_submission_values()`` including:
+
+   - All supported slots
+   - Parameter details
+   - Return value structure
+   - Error handling
+   - Examples
+
+:doc:`../cli`
+   Command-line interface for getting values without writing code
+
+:doc:`../api/providers`
+   Details about data providers for each slot type
+
+Underlying Services
+-------------------
+
+The ``get_submission_values()`` function coordinates multiple specialized services:
+
+- **Climate service**: Annual precipitation and temperature normals
+- **Elevation service**: Elevation above sea level
+- **Weather service**: Current/historical weather data (requires datetime)
+- **Marine service**: Ocean depth and conditions
+- **Soil service**: Soil properties
+- **Geocoding services**: Location names and geographic features
+
+These services are abstracted away for simplicity, but you can read about their internal architecture in :doc:`../architecture`.
+
+CLI Tools
+---------
+
+Use the main CLI for most tasks:
+
+.. code-block:: bash
+
+   biosample-enricher --lat 37.7749 --lon -122.4194 --slots annual_precpt annual_temp
+
+See :doc:`../cli` for complete CLI documentation.
+
+Related Documentation
+---------------------
+
+- :doc:`../quickstart` - Get started in 3 steps
+- :doc:`../architecture` - System architecture overview
+- :doc:`../api/services` - Service API reference (advanced users)

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -1,4 +1,52 @@
 Testing
 =======
 
-Coming soon.
+Comprehensive testing guide for biosample-enricher.
+
+.. include:: ../TESTING.md
+   :parser: myst_parser.sphinx_
+
+Quick Start
+-----------
+
+**Run all tests:**
+
+.. code-block:: bash
+
+   uv run pytest
+
+**Run with coverage:**
+
+.. code-block:: bash
+
+   uv run pytest --cov=biosample_enricher --cov-report=term-missing
+
+**Skip network tests (fast):**
+
+.. code-block:: bash
+
+   uv run pytest -m "not network"
+
+**Run only network tests:**
+
+.. code-block:: bash
+
+   uv run pytest -m network
+
+Test Categories
+---------------
+
+Tests are marked with categories:
+
+- ``@pytest.mark.unit`` - Fast, isolated, no external dependencies
+- ``@pytest.mark.integration`` - Multiple components, mocked externals
+- ``@pytest.mark.network`` - Real API calls (skipped in CI)
+- ``@pytest.mark.slow`` - Performance/timing tests
+- ``@pytest.mark.flaky`` - Known intermittent failures (see :doc:`provider_reliability`)
+
+Related Documentation
+---------------------
+
+- `Flaky Tests <https://github.com/contextualizer-ai/biosample-enricher/blob/main/docs/flaky-tests.md>`_ - Known test reliability issues
+- :doc:`provider_reliability` - Provider stability analysis
+- :doc:`contributing` - How to contribute tests


### PR DESCRIPTION


Addresses issue #203 by removing all "Coming soon" stubs.

Documentation updates:
- Populated license.rst (includes LICENSE file)
- Populated contributing.rst (includes CONTRIBUTING.md)
- Populated changelog.rst (links to GitHub releases)
- Populated architecture.rst (focused on get_submission_values design)
- Populated api/models.rst (auto-documents all model modules)
- Populated services/index.rst (redirects to submission_values)
- Updated all stub pages to use uv instead of pip

Index page improvements:
- Updated overview to focus on NMDC submissions
- Changed "8 specialized services" to "one function" messaging
- Updated quick start to show get_submission_values()
- Made submission_values.rst more prominent in toctree

Also:
- Added MCP server cache files to .gitignore

All "Coming soon" stubs have been replaced with useful content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


